### PR TITLE
Add `provision` and `flow`

### DIFF
--- a/examples/endpoint_provision.rs
+++ b/examples/endpoint_provision.rs
@@ -49,7 +49,9 @@ fn main() {
         .build()
         .unwrap();
 
-    session.endpoint_provision(endpoint_props.clone()).unwrap();
+    session
+        .endpoint_provision(endpoint_props.clone(), true)
+        .unwrap();
     println!("Provisioned endpoint try-me");
 
     let sleep_duration = Duration::from_secs(5);
@@ -59,6 +61,6 @@ fn main() {
     );
     thread::sleep(sleep_duration);
 
-    session.endpoint_deprovision(endpoint_props).unwrap();
+    session.endpoint_deprovision(endpoint_props, true).unwrap();
     println!("Deprovisioned endpoint try-me");
 }

--- a/examples/endpoint_provision.rs
+++ b/examples/endpoint_provision.rs
@@ -1,0 +1,64 @@
+use std::{thread, time::Duration};
+
+/**
+Example showing how to create a solace context, session and provision/deprovision an endpoint using
+the session.
+*/
+use solace_rs::{
+    endpoint_props::{
+        EndpointAccessType, EndpointDiscardBehavior, EndpointId, EndpointPermission,
+        EndpointPropsBuilder,
+    },
+    message::InboundMessage,
+    session::SessionEvent,
+    Context, SolaceLogLevel,
+};
+
+fn main() {
+    let solace_context = Context::new(SolaceLogLevel::Warning).unwrap();
+    println!("Context created");
+
+    let session = solace_context
+        .session_builder()
+        .host_name("tcp://localhost:55554")
+        .vpn_name("default")
+        .username("default")
+        .password("")
+        .client_name("Sol Client")
+        .application_description("This is a library")
+        .on_message(move |message: InboundMessage| {
+            println!("on_message handler got: {:#?} ", message);
+        })
+        .on_event(|e: SessionEvent| {
+            println!("on_event handler got: {}", e);
+        })
+        .build()
+        .unwrap();
+
+    let endpoint_props = EndpointPropsBuilder::new()
+        .id(EndpointId::Queue)
+        .name("try-me")
+        .durable(true)
+        .permission(EndpointPermission::Consume)
+        .access_type(EndpointAccessType::NonExclusive)
+        .quota_mb(10)
+        .max_msg_size(1024)
+        .respects_msg_ttl(true)
+        .discard_behavior(EndpointDiscardBehavior::DiscardNotifySenderOn)
+        .max_msg_redelivery(5)
+        .build()
+        .unwrap();
+
+    session.endpoint_provision(endpoint_props.clone()).unwrap();
+    println!("Provisioned endpoint try-me");
+
+    let sleep_duration = Duration::from_secs(5);
+    println!(
+        "Sleeping for {:?} before deprovisioning, check queue created",
+        sleep_duration
+    );
+    thread::sleep(sleep_duration);
+
+    session.endpoint_deprovision(endpoint_props).unwrap();
+    println!("Deprovisioned endpoint try-me");
+}

--- a/examples/flow_subscriber.rs
+++ b/examples/flow_subscriber.rs
@@ -13,7 +13,7 @@ use solace_rs::{
         builder::{FlowAckMode, FlowBindEntityDurable, FlowBindEntityId},
         event::FlowEvent,
     },
-    message::InboundMessage,
+    message::{inbound::FlowInboundMessage, InboundMessage},
     session::SessionEvent,
     Context, SolaceLogLevel,
 };
@@ -82,8 +82,12 @@ fn main() {
         .reconnect_retry_interval_ms(500)
         .required_outcome_failed(false)
         .required_outcome_rejected(false)
-        .on_message(move |message: InboundMessage| {
+        .on_message(move |message: FlowInboundMessage| {
             println!("on_message handler in flow got: {:#?} ", message);
+            match message.try_ack() {
+                Ok(_) => println!("Acked message"),
+                Err(e) => println!("Failed to ack message: {}", e),
+            }
         })
         .on_event(|event: FlowEvent| {
             println!("on_event handler in flow got: {:#?}", event);

--- a/examples/flow_subscriber.rs
+++ b/examples/flow_subscriber.rs
@@ -1,13 +1,17 @@
 use std::{thread, time::Duration};
 
 /**
-Example showing how to create a solace context, session and provision/deprovision an endpoint using
+Example showing how to create a solace context, session and flow using
 the session.
+This example creates a flow to a queue and consumes messages from it.
 */
 use solace_rs::{
     endpoint_props::{
-        EndpointAccessType, EndpointDiscardBehavior, EndpointId, EndpointPermission,
-        EndpointPropsBuilder,
+        EndpointDiscardBehavior, EndpointId, EndpointPermission, EndpointPropsBuilder,
+    },
+    flow::{
+        builder::{FlowAckMode, FlowBindEntityDurable, FlowBindEntityId},
+        event::FlowEvent,
     },
     message::InboundMessage,
     session::SessionEvent,
@@ -39,9 +43,7 @@ fn main() {
         .id(EndpointId::Queue {
             name: "try-me".to_string(),
         })
-        .durable(true)
         .permission(EndpointPermission::Consume)
-        .access_type(EndpointAccessType::NonExclusive)
         .quota_mb(10)
         .max_msg_size(1024)
         .respects_msg_ttl(true)
@@ -55,11 +57,43 @@ fn main() {
         .unwrap();
     println!("Provisioned endpoint try-me");
 
+    // Note: flow will be destroyed when it dropped
+    let _flow = session
+        .flow_builder()
+        .bind_timeout_ms(5000)
+        .bind_entity_id(FlowBindEntityId::Queue {
+            queue_name: "try-me".to_string(),
+        })
+        .bind_entity_durable(FlowBindEntityDurable::Durable)
+        .window_size(100)
+        .ack_mode(FlowAckMode::Client)
+        .topic("try-me".to_string())
+        .max_bind_tries(5)
+        .ack_timer_ms(100)
+        .ack_threshold(50)
+        .start_state(true)
+        // .selector()
+        .no_local(true)
+        .max_unacked_messages(10)
+        .browser(false)
+        .active_flow_ind(true)
+        // .replay_start_location()
+        .max_reconnect_tries(5)
+        .reconnect_retry_interval_ms(500)
+        .required_outcome_failed(false)
+        .required_outcome_rejected(false)
+        .on_message(move |message: InboundMessage| {
+            println!("on_message handler in flow got: {:#?} ", message);
+        })
+        .on_event(|event: FlowEvent| {
+            println!("on_event handler in flow got: {:#?}", event);
+        })
+        .build()
+        .unwrap();
+    println!("Flow created");
+
     let sleep_duration = Duration::from_secs(5);
-    println!(
-        "Sleeping for {:?} before deprovisioning, check queue created",
-        sleep_duration
-    );
+    println!("Sleeping for {:?} before close flow", sleep_duration);
     thread::sleep(sleep_duration);
 
     session.endpoint_deprovision(endpoint_props, true).unwrap();

--- a/src/endpoint_props.rs
+++ b/src/endpoint_props.rs
@@ -1,4 +1,3 @@
-use enum_primitive::*;
 use solace_rs_sys as ffi;
 use std::{
     ffi::{CString, NulError},
@@ -225,14 +224,12 @@ impl EndpointProps {
     }
 }
 
-enum_from_primitive! {
-    #[derive(Debug, PartialEq, Eq, Default, Clone)]
-    pub enum EndpointId {
-        Queue,
-        #[default]
-        Te,
-        ClientName,
-    }
+#[derive(Debug, PartialEq, Eq, Default, Clone)]
+pub enum EndpointId {
+    Queue,
+    #[default]
+    Te,
+    ClientName,
 }
 impl EndpointId {
     fn as_ptr(&self) -> *const i8 {
@@ -245,15 +242,13 @@ impl EndpointId {
     }
 }
 
-enum_from_primitive! {
-    #[derive(Debug, PartialEq, Eq, Clone)]
-    pub enum EndpointPermission {
-        Delete,
-        ModifyTopic,
-        Consume,
-        ReadOnly,
-        None,
-    }
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EndpointPermission {
+    Delete,
+    ModifyTopic,
+    Consume,
+    ReadOnly,
+    None,
 }
 impl EndpointPermission {
     pub fn as_ptr(&self) -> *const i8 {
@@ -268,12 +263,10 @@ impl EndpointPermission {
     }
 }
 
-enum_from_primitive! {
-    #[derive(Debug, PartialEq, Eq, Clone)]
-    pub enum EndpointAccessType {
-        Exclusive,
-        NonExclusive,
-    }
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EndpointAccessType {
+    Exclusive,
+    NonExclusive,
 }
 impl EndpointAccessType {
     pub fn as_ptr(&self) -> *const i8 {
@@ -285,12 +278,10 @@ impl EndpointAccessType {
     }
 }
 
-enum_from_primitive! {
-    #[derive(Debug, PartialEq, Eq, Clone)]
-    pub enum EndpointDiscardBehavior {
-        DiscardNotifySenderOff,
-        DiscardNotifySenderOn,
-    }
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum EndpointDiscardBehavior {
+    DiscardNotifySenderOff,
+    DiscardNotifySenderOn,
 }
 impl EndpointDiscardBehavior {
     pub fn as_ptr(&self) -> *const i8 {

--- a/src/endpoint_props.rs
+++ b/src/endpoint_props.rs
@@ -49,39 +49,72 @@ impl EndpointPropsBuilder {
         }
     }
 
+    /// Sets the type of endpoint.
+    ///
+    /// The valid values are SOLCLIENT_ENDPOINT_PROP_QUEUE, SOLCLIENT_ENDPOINT_PROP_TE, and SOLCLIENT_ENDPOINT_PROP_CLIENT_NAME.
+    /// Default: [ffi::SOLCLIENT_ENDPOINT_PROP_TE]
     pub fn id(mut self, id: EndpointId<String>) -> Self {
         self.id = Some(id);
         self
     }
 
+    /// Sets the durability of the endpoint.
+    ///
+    /// Default: [ffi::SOLCLIENT_PROP_ENABLE_VAL], which means the endpoint is durable. Only SOLCLIENT_PROP_ENABLE_VAL is supported in solClient_session_endpointProvision().
     pub fn durable(mut self, durable: bool) -> Self {
         self.durable = Some(durable);
         self
     }
+
+    /// Sets the permissions for the created entity.
+    ///
+    /// Permissions can be SOLCLIENT_ENDPOINT_PERM_DELETE, SOLCLIENT_ENDPOINT_PERM_MODIFY_TOPIC, SOLCLIENT_ENDPOINT_PERM_CONSUME, SOLCLIENT_ENDPOINT_PERM_READ_ONLY, SOLCLIENT_ENDPOINT_PERM_NONE.
     pub fn permission(mut self, permission: EndpointPermission) -> Self {
         self.permission = Some(permission);
         self
     }
+
+    /// Sets the access type for the endpoint.
+    ///
+    /// This applies to durable Queues only.
     pub fn access_type(mut self, access_type: EndpointAccessType) -> Self {
         self.access_type = Some(access_type);
         self
     }
+
+    /// Sets the maximum quota (in megabytes) for the endpoint.
+    ///
+    /// A value of 0 configures the endpoint to act as a Last-Value-Queue (LVQ), where the broker enforces a Queue depth of one.
     pub fn quota_mb(mut self, quota_mb: u64) -> Self {
         self.quota_mb = Some(quota_mb);
         self
     }
+
+    /// Sets the maximum size (in bytes) for any one message stored in the endpoint.
     pub fn max_msg_size(mut self, max_msg_size: u64) -> Self {
         self.max_msg_size = Some(max_msg_size);
         self
     }
+
+    /// Configures the endpoint to observe message Time-to-Live (TTL) values and remove expired messages.
+    ///
+    /// Default: [ffi::SOLCLIENT_ENDPOINT_PROP_DEFAULT_RESPECTS_MSG_TTL]
     pub fn respects_msg_ttl(mut self, respects_msg_ttl: bool) -> Self {
         self.respects_msg_ttl = Some(respects_msg_ttl);
         self
     }
+
+    /// Sets the discard behavior for the endpoint.
+    ///
+    /// When a message cannot be added to an endpoint (e.g., maximum quota exceeded), this property controls the action the broker will perform towards the publisher.
     pub fn discard_behavior(mut self, discard_behavior: EndpointDiscardBehavior) -> Self {
         self.discard_behavior = Some(discard_behavior);
         self
     }
+
+    /// Defines how many message redelivery retries before discarding or moving the message to the DMQ.
+    ///
+    /// The valid range is {0..255}, where 0 means retry forever. Default: 0
     pub fn max_msg_redelivery(mut self, max_msg_redelivery: u64) -> Self {
         self.max_msg_redelivery = Some(max_msg_redelivery);
         self

--- a/src/endpoint_props.rs
+++ b/src/endpoint_props.rs
@@ -1,0 +1,303 @@
+use enum_primitive::*;
+use solace_rs_sys as ffi;
+use std::{
+    ffi::{CString, NulError},
+    ptr,
+};
+use thiserror::Error;
+
+use crate::util::bool_to_ptr;
+
+type Result<T> = std::result::Result<T, EndpointPropsBuilderError>;
+
+#[derive(Error, Debug)]
+pub enum EndpointPropsBuilderError {
+    #[error("builder recieved invalid args")]
+    InvalidArgs(#[from] NulError),
+    #[error("{0} arg need to be set")]
+    MissingRequiredArgs(String),
+    #[error("{0} size need to be less than {1} found {2}")]
+    SizeErrorArgs(String, usize, usize),
+}
+
+/// Endpoint Configuration Properties
+/// https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/group__endpoint_props.html
+pub struct EndpointPropsBuilder<Id, Name> {
+    // Note: required params
+    // In the future we can use type state pattern to always force clients to provide these params
+    id: Option<Id>,
+    name: Option<Name>,
+
+    durable: Option<bool>,
+    permission: Option<EndpointPermission>,
+    access_type: Option<EndpointAccessType>,
+    quota_mb: Option<u64>,
+    max_msg_size: Option<u64>,
+    respects_msg_ttl: Option<bool>,
+    discard_behavior: Option<EndpointDiscardBehavior>,
+    max_msg_redelivery: Option<u64>,
+}
+
+impl<Id, Name> EndpointPropsBuilder<Id, Name>
+where
+    Id: Into<EndpointId>,
+    Name: Into<String>,
+{
+    /// Creates a new `EndpointPropsBuilder` with default properties.
+    pub fn new() -> Self {
+        Self {
+            id: None,
+            name: None,
+            durable: None,
+            permission: None,
+            access_type: None,
+            quota_mb: None,
+            max_msg_size: None,
+            respects_msg_ttl: None,
+            discard_behavior: None,
+            max_msg_redelivery: None,
+        }
+    }
+
+    pub fn id(mut self, id: Id) -> Self {
+        self.id = Some(id);
+        self
+    }
+
+    pub fn name(mut self, name: Name) -> Self {
+        self.name = Some(name);
+        self
+    }
+
+    pub fn durable(mut self, durable: bool) -> Self {
+        self.durable = Some(durable);
+        self
+    }
+    pub fn permission(mut self, permission: EndpointPermission) -> Self {
+        self.permission = Some(permission);
+        self
+    }
+    pub fn access_type(mut self, access_type: EndpointAccessType) -> Self {
+        self.access_type = Some(access_type);
+        self
+    }
+    pub fn quota_mb(mut self, quota_mb: u64) -> Self {
+        self.quota_mb = Some(quota_mb);
+        self
+    }
+    pub fn max_msg_size(mut self, max_msg_size: u64) -> Self {
+        self.max_msg_size = Some(max_msg_size);
+        self
+    }
+    pub fn respects_msg_ttl(mut self, respects_msg_ttl: bool) -> Self {
+        self.respects_msg_ttl = Some(respects_msg_ttl);
+        self
+    }
+    pub fn discard_behavior(mut self, discard_behavior: EndpointDiscardBehavior) -> Self {
+        self.discard_behavior = Some(discard_behavior);
+        self
+    }
+    pub fn max_msg_redelivery(mut self, max_msg_redelivery: u64) -> Self {
+        self.max_msg_redelivery = Some(max_msg_redelivery);
+        self
+    }
+
+    pub fn build(self) -> Result<EndpointProps> {
+        println!("Building EndpointProps");
+
+        let id = match self.id {
+            Some(id) => id.into(),
+            None => {
+                return Err(EndpointPropsBuilderError::MissingRequiredArgs(
+                    "id".to_string(),
+                ))
+            }
+        };
+        let name = match self.name {
+            Some(name) => CString::new(name.into())?,
+            None => {
+                return Err(EndpointPropsBuilderError::MissingRequiredArgs(
+                    "name".to_string(),
+                ))
+            }
+        };
+        let durable = self.durable;
+        let permission = self.permission;
+        let access_type = self.access_type;
+        let quota_mb = self
+            .quota_mb
+            .map(|q| CString::new(q.to_string()))
+            .transpose()?;
+        let max_msg_size = self
+            .max_msg_size
+            .map(|m| CString::new(m.to_string()))
+            .transpose()?;
+        let respects_msg_ttl = self.respects_msg_ttl;
+        let discard_behavior = self.discard_behavior;
+        let max_msg_redelivery = self
+            .max_msg_redelivery
+            .map(|m| CString::new(m.to_string()))
+            .transpose()?;
+
+        Ok(EndpointProps {
+            id,
+            name,
+            durable,
+            permission,
+            access_type,
+            quota_mb,
+            max_msg_size,
+            respects_msg_ttl,
+            discard_behavior,
+            max_msg_redelivery,
+        })
+    }
+}
+
+#[derive(Debug, Clone)]
+pub struct EndpointProps {
+    id: EndpointId,
+    name: CString,
+
+    // Note: optional params
+    durable: Option<bool>,
+    permission: Option<EndpointPermission>,
+    access_type: Option<EndpointAccessType>,
+    quota_mb: Option<CString>,
+    max_msg_size: Option<CString>,
+    respects_msg_ttl: Option<bool>,
+    discard_behavior: Option<EndpointDiscardBehavior>,
+    max_msg_redelivery: Option<CString>,
+}
+
+impl EndpointProps {
+    pub fn to_raw(&self) -> Vec<*const i8> {
+        let mut props = vec![
+            ffi::SOLCLIENT_ENDPOINT_PROP_ID.as_ptr() as *const i8,
+            self.id.as_ptr(),
+            ffi::SOLCLIENT_ENDPOINT_PROP_NAME.as_ptr() as *const i8,
+            self.name.as_ptr() as *const i8,
+        ];
+
+        if let Some(durable) = self.durable {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_DURABLE.as_ptr() as *const i8);
+            props.push(bool_to_ptr(durable));
+        }
+
+        if let Some(permission) = &self.permission {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_PERMISSION.as_ptr() as *const i8);
+            props.push(permission.as_ptr());
+        }
+
+        if let Some(access_type) = &self.access_type {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_ACCESSTYPE.as_ptr() as *const i8);
+            props.push(access_type.as_ptr());
+        }
+
+        if let Some(quota_mb) = &self.quota_mb {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_QUOTA_MB.as_ptr() as *const i8);
+            props.push(quota_mb.as_ptr() as *const i8);
+        }
+
+        if let Some(max_msg_size) = &self.max_msg_size {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_MAXMSG_SIZE.as_ptr() as *const i8);
+            props.push(max_msg_size.as_ptr() as *const i8);
+        }
+
+        if let Some(respects_msg_ttl) = self.respects_msg_ttl {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_RESPECTS_MSG_TTL.as_ptr() as *const i8);
+            props.push(bool_to_ptr(respects_msg_ttl));
+        }
+
+        if let Some(discard_behavior) = &self.discard_behavior {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_DISCARD_BEHAVIOR.as_ptr() as *const i8);
+            props.push(discard_behavior.as_ptr());
+        }
+
+        if let Some(max_msg_redelivery) = &self.max_msg_redelivery {
+            props.push(ffi::SOLCLIENT_ENDPOINT_PROP_MAXMSG_REDELIVERY.as_ptr() as *const i8);
+            props.push(max_msg_redelivery.as_ptr() as *const i8);
+        }
+
+        props.push(ptr::null());
+
+        props
+    }
+}
+
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Eq, Default, Clone)]
+    pub enum EndpointId {
+        Queue,
+        #[default]
+        Te,
+        ClientName,
+    }
+}
+impl EndpointId {
+    fn as_ptr(&self) -> *const i8 {
+        match self {
+            Self::Queue => ffi::SOLCLIENT_ENDPOINT_PROP_QUEUE,
+            Self::Te => ffi::SOLCLIENT_ENDPOINT_PROP_TE,
+            Self::ClientName => ffi::SOLCLIENT_ENDPOINT_PROP_CLIENT_NAME,
+        }
+        .as_ptr() as *const i8
+    }
+}
+
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    pub enum EndpointPermission {
+        Delete,
+        ModifyTopic,
+        Consume,
+        ReadOnly,
+        None,
+    }
+}
+impl EndpointPermission {
+    pub fn as_ptr(&self) -> *const i8 {
+        match self {
+            Self::Delete => ffi::SOLCLIENT_ENDPOINT_PERM_DELETE,
+            Self::ModifyTopic => ffi::SOLCLIENT_ENDPOINT_PERM_MODIFY_TOPIC,
+            Self::Consume => ffi::SOLCLIENT_ENDPOINT_PERM_CONSUME,
+            Self::ReadOnly => ffi::SOLCLIENT_ENDPOINT_PERM_READ_ONLY,
+            Self::None => ffi::SOLCLIENT_ENDPOINT_PERM_NONE,
+        }
+        .as_ptr() as *const i8
+    }
+}
+
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    pub enum EndpointAccessType {
+        Exclusive,
+        NonExclusive,
+    }
+}
+impl EndpointAccessType {
+    pub fn as_ptr(&self) -> *const i8 {
+        match self {
+            Self::Exclusive => ffi::SOLCLIENT_ENDPOINT_PROP_ACCESSTYPE_EXCLUSIVE,
+            Self::NonExclusive => ffi::SOLCLIENT_ENDPOINT_PROP_ACCESSTYPE_NONEXCLUSIVE,
+        }
+        .as_ptr() as *const i8
+    }
+}
+
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Eq, Clone)]
+    pub enum EndpointDiscardBehavior {
+        DiscardNotifySenderOff,
+        DiscardNotifySenderOn,
+    }
+}
+impl EndpointDiscardBehavior {
+    pub fn as_ptr(&self) -> *const i8 {
+        match self {
+            Self::DiscardNotifySenderOff => ffi::SOLCLIENT_ENDPOINT_PROP_DISCARD_NOTIFY_SENDER_OFF,
+            Self::DiscardNotifySenderOn => ffi::SOLCLIENT_ENDPOINT_PROP_DISCARD_NOTIFY_SENDER_ON,
+        }
+        .as_ptr() as *const i8
+    }
+}

--- a/src/endpoint_props.rs
+++ b/src/endpoint_props.rs
@@ -15,8 +15,6 @@ pub enum EndpointPropsBuilderError {
     InvalidArgs(#[from] NulError),
     #[error("{0} arg need to be set")]
     MissingRequiredArgs(String),
-    #[error("{0} size need to be less than {1} found {2}")]
-    SizeErrorArgs(String, usize, usize),
 }
 
 /// Endpoint Configuration Properties
@@ -26,11 +24,11 @@ pub struct EndpointPropsBuilder {
     durable: Option<bool>,
     permission: Option<EndpointPermission>,
     access_type: Option<EndpointAccessType>,
-    quota_mb: Option<u64>,
-    max_msg_size: Option<u64>,
+    quota_mb: Option<u32>,
+    max_msg_size: Option<u32>,
     respects_msg_ttl: Option<bool>,
     discard_behavior: Option<EndpointDiscardBehavior>,
-    max_msg_redelivery: Option<u64>,
+    max_msg_redelivery: Option<u8>,
 }
 
 impl EndpointPropsBuilder {
@@ -85,13 +83,13 @@ impl EndpointPropsBuilder {
     /// Sets the maximum quota (in megabytes) for the endpoint.
     ///
     /// A value of 0 configures the endpoint to act as a Last-Value-Queue (LVQ), where the broker enforces a Queue depth of one.
-    pub fn quota_mb(mut self, quota_mb: u64) -> Self {
+    pub fn quota_mb(mut self, quota_mb: u32) -> Self {
         self.quota_mb = Some(quota_mb);
         self
     }
 
     /// Sets the maximum size (in bytes) for any one message stored in the endpoint.
-    pub fn max_msg_size(mut self, max_msg_size: u64) -> Self {
+    pub fn max_msg_size(mut self, max_msg_size: u32) -> Self {
         self.max_msg_size = Some(max_msg_size);
         self
     }
@@ -115,7 +113,7 @@ impl EndpointPropsBuilder {
     /// Defines how many message redelivery retries before discarding or moving the message to the DMQ.
     ///
     /// The valid range is {0..255}, where 0 means retry forever. Default: 0
-    pub fn max_msg_redelivery(mut self, max_msg_redelivery: u64) -> Self {
+    pub fn max_msg_redelivery(mut self, max_msg_redelivery: u8) -> Self {
         self.max_msg_redelivery = Some(max_msg_redelivery);
         self
     }

--- a/src/endpoint_props.rs
+++ b/src/endpoint_props.rs
@@ -11,7 +11,7 @@ type Result<T> = std::result::Result<T, EndpointPropsBuilderError>;
 
 #[derive(Error, Debug)]
 pub enum EndpointPropsBuilderError {
-    #[error("builder recieved invalid args")]
+    #[error("builder received invalid args")]
     InvalidArgs(#[from] NulError),
     #[error("{0} arg need to be set")]
     MissingRequiredArgs(String),

--- a/src/endpoint_props.rs
+++ b/src/endpoint_props.rs
@@ -31,6 +31,12 @@ pub struct EndpointPropsBuilder {
     max_msg_redelivery: Option<u8>,
 }
 
+impl Default for EndpointPropsBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 impl EndpointPropsBuilder {
     /// Creates a new `EndpointPropsBuilder` with default properties.
     pub fn new() -> Self {
@@ -207,12 +213,12 @@ impl EndpointProps {
 
         if let Some(quota_mb) = &self.quota_mb {
             props.push(ffi::SOLCLIENT_ENDPOINT_PROP_QUOTA_MB.as_ptr() as *const i8);
-            props.push(quota_mb.as_ptr() as *const i8);
+            props.push(quota_mb.as_ptr());
         }
 
         if let Some(max_msg_size) = &self.max_msg_size {
             props.push(ffi::SOLCLIENT_ENDPOINT_PROP_MAXMSG_SIZE.as_ptr() as *const i8);
-            props.push(max_msg_size.as_ptr() as *const i8);
+            props.push(max_msg_size.as_ptr());
         }
 
         if let Some(respects_msg_ttl) = self.respects_msg_ttl {
@@ -227,7 +233,7 @@ impl EndpointProps {
 
         if let Some(max_msg_redelivery) = &self.max_msg_redelivery {
             props.push(ffi::SOLCLIENT_ENDPOINT_PROP_MAXMSG_REDELIVERY.as_ptr() as *const i8);
-            props.push(max_msg_redelivery.as_ptr() as *const i8);
+            props.push(max_msg_redelivery.as_ptr());
         }
 
         props.push(ptr::null());

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -1,0 +1,60 @@
+pub mod builder;
+pub(crate) mod callback;
+pub mod event;
+
+use event::FlowEvent;
+use solace_rs_sys as ffi;
+use std::marker::PhantomData;
+use tracing::warn;
+
+use crate::{message::InboundMessage, session::SessionEvent, Session, SolClientReturnCode};
+
+pub struct Flow<
+    'flow,
+    'session,
+    SM: FnMut(InboundMessage) + Send + 'session,
+    SE: FnMut(SessionEvent) + Send + 'session,
+    FM: FnMut(InboundMessage) + Send + 'flow,
+    FE: FnMut(FlowEvent) + Send + 'flow,
+> {
+    pub(crate) lifetime: PhantomData<&'flow ()>,
+
+    // Pointer to flow
+    // This pointer must never be allowed to leave the struct
+    pub(crate) _flow_ptr: ffi::solClient_opaqueFlow_pt,
+
+    #[allow(dead_code)]
+    pub(crate) session: &'flow Session<'session, SM, SE>,
+
+    // These fields are used to store the fn callback. The mutable reference to this fn is passed to the FFI library,
+    #[allow(dead_code, clippy::redundant_allocation)]
+    _msg_fn_ptr: Option<Box<Box<FM>>>,
+    #[allow(dead_code, clippy::redundant_allocation)]
+    _event_fn_ptr: Option<Box<Box<FE>>>,
+}
+
+unsafe impl<
+        SM: FnMut(InboundMessage) + Send,
+        SE: FnMut(SessionEvent) + Send,
+        FM: FnMut(InboundMessage) + Send,
+        FE: FnMut(FlowEvent) + Send,
+    > Send for Flow<'_, '_, SM, SE, FM, FE>
+{
+}
+
+impl<
+        SM: FnMut(InboundMessage) + Send,
+        SE: FnMut(SessionEvent) + Send,
+        FM: FnMut(InboundMessage) + Send,
+        FE: FnMut(FlowEvent) + Send,
+    > Drop for Flow<'_, '_, SM, SE, FM, FE>
+{
+    fn drop(&mut self) {
+        let session_free_result = unsafe { ffi::solClient_flow_destroy(&mut self._flow_ptr) };
+        let rc = SolClientReturnCode::from_raw(session_free_result);
+
+        if !rc.is_ok() {
+            warn!("flow was not dropped properly. {rc}");
+        }
+    }
+}

--- a/src/flow.rs
+++ b/src/flow.rs
@@ -7,14 +7,18 @@ use solace_rs_sys as ffi;
 use std::marker::PhantomData;
 use tracing::warn;
 
-use crate::{message::InboundMessage, session::SessionEvent, Session, SolClientReturnCode};
+use crate::{
+    message::{inbound::FlowInboundMessage, InboundMessage},
+    session::SessionEvent,
+    Session, SolClientReturnCode,
+};
 
 pub struct Flow<
     'flow,
     'session,
     SM: FnMut(InboundMessage) + Send + 'session,
     SE: FnMut(SessionEvent) + Send + 'session,
-    FM: FnMut(InboundMessage) + Send + 'flow,
+    FM: FnMut(FlowInboundMessage) + Send + 'flow,
     FE: FnMut(FlowEvent) + Send + 'flow,
 > {
     pub(crate) lifetime: PhantomData<&'flow ()>,
@@ -36,7 +40,7 @@ pub struct Flow<
 unsafe impl<
         SM: FnMut(InboundMessage) + Send,
         SE: FnMut(SessionEvent) + Send,
-        FM: FnMut(InboundMessage) + Send,
+        FM: FnMut(FlowInboundMessage) + Send,
         FE: FnMut(FlowEvent) + Send,
     > Send for Flow<'_, '_, SM, SE, FM, FE>
 {
@@ -45,7 +49,7 @@ unsafe impl<
 impl<
         SM: FnMut(InboundMessage) + Send,
         SE: FnMut(SessionEvent) + Send,
-        FM: FnMut(InboundMessage) + Send,
+        FM: FnMut(FlowInboundMessage) + Send,
         FE: FnMut(FlowEvent) + Send,
     > Drop for Flow<'_, '_, SM, SE, FM, FE>
 {

--- a/src/flow/builder.rs
+++ b/src/flow/builder.rs
@@ -7,7 +7,7 @@ use std::{
 
 use crate::{
     endpoint_props::EndpointProps,
-    message::InboundMessage,
+    message::{inbound::FlowInboundMessage, InboundMessage},
     session::SessionEvent,
     util::{bool_to_ptr, get_last_error_info},
     Session, SolClientReturnCode, SolClientSubCode,
@@ -90,7 +90,7 @@ impl<'builder, 'flow, 'session, SM, SE, FM, FE> FlowBuilder<'builder, 'session, 
 where
     SM: FnMut(InboundMessage) + Send + 'session,
     SE: FnMut(SessionEvent) + Send + 'session,
-    FM: FnMut(InboundMessage) + Send + 'flow,
+    FM: FnMut(FlowInboundMessage) + Send + 'flow,
     FE: FnMut(FlowEvent) + Send + 'flow,
     'builder: 'flow,
 {

--- a/src/flow/builder.rs
+++ b/src/flow/builder.rs
@@ -146,8 +146,9 @@ where
             };
 
         let flow_create_raw_rc = unsafe {
+            let mut checked_props_raw = checked_props.to_raw();
             ffi::solClient_session_createFlow(
-                checked_props.to_raw().as_mut_ptr(),
+                checked_props_raw.as_mut_ptr(),
                 self.session._session_ptr,
                 &mut flow_ptr,
                 &mut flow_func_info,

--- a/src/flow/builder.rs
+++ b/src/flow/builder.rs
@@ -1,0 +1,590 @@
+use solace_rs_sys as ffi;
+use std::{
+    ffi::{CString, NulError},
+    marker::PhantomData,
+    ptr,
+};
+
+use crate::{
+    endpoint_props::EndpointProps,
+    message::InboundMessage,
+    session::SessionEvent,
+    util::{bool_to_ptr, get_last_error_info},
+    Session, SolClientReturnCode, SolClientSubCode,
+};
+
+use super::{
+    callback::{
+        on_event_trampoline, on_message_trampoline, static_no_op_on_event, static_no_op_on_message,
+    },
+    event::FlowEvent,
+    Flow,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum FlowBuilderError {
+    #[error("flow failed to initialize. SolClient return code: {0} subcode: {1}")]
+    InitializationFailure(SolClientReturnCode, SolClientSubCode),
+    #[error("arg contains interior nul byte")]
+    InvalidArgs(#[from] NulError),
+}
+
+type Result<T> = std::result::Result<T, FlowBuilderError>;
+
+#[derive(Debug, PartialEq, Eq, Clone, Default)]
+struct UncheckedFlowProps {
+    bind_timeout_ms: Option<u32>,
+    bind_entity_id: Option<FlowBindEntityId<String>>,
+    bind_entity_durable: Option<FlowBindEntityDurable>,
+    window_size: Option<u32>,
+    ack_mode: Option<FlowAckMode>,
+    topic: Option<String>,
+    max_bind_tries: Option<u32>,
+    ack_timer_ms: Option<u32>,
+    ack_threshold: Option<u8>,
+    start_state: Option<bool>,
+    selector: Option<String>,
+    no_local: Option<bool>,
+    max_unacked_messages: Option<u32>,
+    browser: Option<bool>,
+    active_flow_ind: Option<bool>,
+    replay_start_location: Option<String>,
+    max_reconnect_tries: Option<u32>,
+    reconnect_retry_interval_ms: Option<u32>,
+    required_outcome_failed: Option<bool>,
+    required_outcome_rejected: Option<bool>,
+    // Note: Blocking only supported for now
+    // bind_blocking: Option<bool>,
+}
+
+pub struct FlowBuilder<'builder, 'session, SM, SE, OnMessage, OnEvent>
+where
+    SM: FnMut(InboundMessage) + Send + 'session,
+    SE: FnMut(SessionEvent) + Send + 'session,
+{
+    session: &'builder Session<'session, SM, SE>,
+    props: UncheckedFlowProps,
+
+    // callbacks
+    on_message: Option<OnMessage>,
+    on_event: Option<OnEvent>,
+}
+
+impl<'builder, 'session, SM, SE, OnMessage, OnEvent>
+    FlowBuilder<'builder, 'session, SM, SE, OnMessage, OnEvent>
+where
+    SM: FnMut(InboundMessage) + Send + 'session,
+    SE: FnMut(SessionEvent) + Send + 'session,
+{
+    pub(crate) fn new(session: &'builder Session<'session, SM, SE>) -> Self {
+        Self {
+            session,
+            props: UncheckedFlowProps::default(),
+            on_message: None,
+            on_event: None,
+        }
+    }
+}
+
+impl<'builder, 'flow, 'session, SM, SE, FM, FE> FlowBuilder<'builder, 'session, SM, SE, FM, FE>
+where
+    SM: FnMut(InboundMessage) + Send + 'session,
+    SE: FnMut(SessionEvent) + Send + 'session,
+    FM: FnMut(InboundMessage) + Send + 'flow,
+    FE: FnMut(FlowEvent) + Send + 'flow,
+    'builder: 'flow,
+{
+    pub fn build(self) -> Result<Flow<'flow, 'session, SM, SE, FM, FE>> {
+        let checked_props = CheckedFlowProps::try_from(self.props)?;
+
+        let mut flow_ptr: ffi::solClient_opaqueFlow_pt = ptr::null_mut();
+
+        let (static_on_message_callback, user_on_message, msg_func_ptr) = match self.on_message {
+            Some(f) => {
+                let tramp = on_message_trampoline(&f);
+                let mut func = Box::new(Box::new(f));
+                (tramp, func.as_mut() as *const _ as *mut _, Some(func))
+            }
+            _ => (
+                Some(static_no_op_on_message as unsafe extern "C" fn(_, _, _) -> u32),
+                std::ptr::null_mut(),
+                None,
+            ),
+        };
+
+        let (static_on_event_callback, user_on_event, event_func_ptr) = match self.on_event {
+            Some(f) => {
+                let tramp = on_event_trampoline(&f);
+                let mut func = Box::new(Box::new(f));
+                (tramp, func.as_mut() as *const _ as *mut _, Some(func))
+            }
+            _ => (
+                Some(static_no_op_on_event as unsafe extern "C" fn(_, _, _)),
+                std::ptr::null_mut(),
+                None,
+            ),
+        };
+
+        let mut flow_func_info: ffi::solClient_flow_createFuncInfo_t =
+            ffi::solClient_flow_createFuncInfo_t {
+                rxInfo: ffi::solClient_flow_createRxCallbackFuncInfo {
+                    callback_p: ptr::null_mut(),
+                    user_p: ptr::null_mut(),
+                },
+                eventInfo: ffi::solClient_flow_createEventCallbackFuncInfo {
+                    callback_p: static_on_event_callback,
+                    user_p: user_on_event,
+                },
+                rxMsgInfo: ffi::solClient_flow_createRxMsgCallbackFuncInfo {
+                    callback_p: static_on_message_callback,
+                    user_p: user_on_message,
+                },
+            };
+
+        let flow_create_raw_rc = unsafe {
+            ffi::solClient_session_createFlow(
+                checked_props.to_raw().as_mut_ptr(),
+                self.session._session_ptr,
+                &mut flow_ptr,
+                &mut flow_func_info,
+                std::mem::size_of::<ffi::solClient_session_createFuncInfo_t>(),
+            )
+        };
+
+        let rc = SolClientReturnCode::from_raw(flow_create_raw_rc);
+        if rc.is_ok() {
+            Ok(Flow {
+                lifetime: PhantomData,
+                _flow_ptr: flow_ptr,
+                session: &self.session,
+                _msg_fn_ptr: msg_func_ptr,
+                _event_fn_ptr: event_func_ptr,
+            })
+        } else {
+            let subcode = get_last_error_info();
+            Err(FlowBuilderError::InitializationFailure(rc, subcode))
+        }
+    }
+
+    pub fn bind_timeout_ms(mut self, timeout: u32) -> Self {
+        self.props.bind_timeout_ms = Some(timeout);
+        self
+    }
+
+    pub fn bind_entity_id(mut self, entity_id: FlowBindEntityId<String>) -> Self {
+        self.props.bind_entity_id = Some(entity_id);
+        self
+    }
+
+    pub fn bind_entity_durable(mut self, durable: FlowBindEntityDurable) -> Self {
+        self.props.bind_entity_durable = Some(durable);
+        self
+    }
+
+    pub fn window_size(mut self, size: u32) -> Self {
+        self.props.window_size = Some(size);
+        self
+    }
+
+    pub fn ack_mode(mut self, mode: FlowAckMode) -> Self {
+        self.props.ack_mode = Some(mode);
+        self
+    }
+
+    pub fn topic(mut self, topic: String) -> Self {
+        self.props.topic = Some(topic);
+        self
+    }
+
+    pub fn max_bind_tries(mut self, tries: u32) -> Self {
+        self.props.max_bind_tries = Some(tries);
+        self
+    }
+
+    pub fn ack_timer_ms(mut self, timer: u32) -> Self {
+        self.props.ack_timer_ms = Some(timer);
+        self
+    }
+
+    pub fn ack_threshold(mut self, threshold: u8) -> Self {
+        self.props.ack_threshold = Some(threshold);
+        self
+    }
+
+    pub fn start_state(mut self, state: bool) -> Self {
+        self.props.start_state = Some(state);
+        self
+    }
+
+    pub fn selector(mut self, selector: String) -> Self {
+        self.props.selector = Some(selector);
+        self
+    }
+
+    pub fn no_local(mut self, no_local: bool) -> Self {
+        self.props.no_local = Some(no_local);
+        self
+    }
+
+    pub fn max_unacked_messages(mut self, max: u32) -> Self {
+        self.props.max_unacked_messages = Some(max);
+        self
+    }
+
+    pub fn browser(mut self, browser: bool) -> Self {
+        self.props.browser = Some(browser);
+        self
+    }
+
+    pub fn active_flow_ind(mut self, active: bool) -> Self {
+        self.props.active_flow_ind = Some(active);
+        self
+    }
+
+    pub fn replay_start_location(mut self, location: String) -> Self {
+        self.props.replay_start_location = Some(location);
+        self
+    }
+
+    pub fn max_reconnect_tries(mut self, tries: u32) -> Self {
+        self.props.max_reconnect_tries = Some(tries);
+        self
+    }
+
+    pub fn reconnect_retry_interval_ms(mut self, interval: u32) -> Self {
+        self.props.reconnect_retry_interval_ms = Some(interval);
+        self
+    }
+
+    pub fn required_outcome_failed(mut self, failed: bool) -> Self {
+        self.props.required_outcome_failed = Some(failed);
+        self
+    }
+
+    pub fn required_outcome_rejected(mut self, rejected: bool) -> Self {
+        self.props.required_outcome_rejected = Some(rejected);
+        self
+    }
+
+    pub fn on_message(mut self, on_message: FM) -> Self {
+        self.on_message = Some(on_message);
+        self
+    }
+
+    pub fn on_event(mut self, on_event: FE) -> Self {
+        self.on_event = Some(on_event);
+        self
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+struct CheckedFlowProps {
+    bind_timeout_ms: Option<CString>,
+    bind_entity_id: Option<FlowBindEntityId<CString>>,
+    bind_entity_durable: Option<FlowBindEntityDurable>,
+    window_size: Option<CString>,
+    ack_mode: Option<FlowAckMode>,
+    topic: Option<CString>,
+    max_bind_tries: Option<CString>,
+    ack_timer_ms: Option<CString>,
+    ack_threshold: Option<CString>,
+    start_state: Option<bool>,
+    selector: Option<CString>,
+    no_local: Option<bool>,
+    max_unacked_messages: Option<CString>,
+    browser: Option<bool>,
+    active_flow_ind: Option<bool>,
+    replay_start_location: Option<CString>,
+    max_reconnect_tries: Option<CString>,
+    reconnect_retry_interval_ms: Option<CString>,
+    required_outcome_failed: Option<bool>,
+    required_outcome_rejected: Option<bool>,
+}
+
+impl CheckedFlowProps {
+    fn to_raw(&self) -> Vec<*const i8> {
+        let mut props = vec![];
+
+        if let Some(bind_timeout_ms) = &self.bind_timeout_ms {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_TIMEOUT_MS.as_ptr() as *const i8);
+            props.push(bind_timeout_ms.as_ptr());
+        }
+
+        if let Some(bind_entity_id) = &self.bind_entity_id {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_ENTITY_ID.as_ptr() as *const i8);
+            match bind_entity_id {
+                FlowBindEntityId::Sub => {
+                    props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_ENTITY_SUB.as_ptr() as *const i8);
+                }
+                FlowBindEntityId::Queue { queue_name } => {
+                    props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_ENTITY_QUEUE.as_ptr() as *const i8);
+                    props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_NAME.as_ptr() as *const i8);
+                    props.push(queue_name.as_ptr());
+                }
+                FlowBindEntityId::Te {
+                    topic_endpoint_name,
+                } => {
+                    props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_ENTITY_TE.as_ptr() as *const i8);
+                    props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_NAME.as_ptr() as *const i8);
+                    props.push(topic_endpoint_name.as_ptr());
+                }
+            }
+        }
+
+        if let Some(bind_entity_durable) = &self.bind_entity_durable {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_BIND_ENTITY_DURABLE.as_ptr() as *const i8);
+
+            match bind_entity_durable {
+                FlowBindEntityDurable::Durable => {
+                    props.push(bool_to_ptr(true));
+                }
+                FlowBindEntityDurable::NonDurable { endpoint_props } => {
+                    props.push(bool_to_ptr(false));
+                    let mut endpoint_props = endpoint_props.to_raw();
+                    // Remove null character on the end
+                    endpoint_props
+                        .pop()
+                        .expect("null character should be removed");
+                    props.extend_from_slice(&endpoint_props);
+                }
+            }
+        }
+
+        if let Some(window_size) = &self.window_size {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_WINDOWSIZE.as_ptr() as *const i8);
+            props.push(window_size.as_ptr());
+        }
+
+        if let Some(ack_mode) = &self.ack_mode {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_ACKMODE.as_ptr() as *const i8);
+            match ack_mode {
+                FlowAckMode::Auto => {
+                    props.push(ffi::SOLCLIENT_FLOW_PROP_ACKMODE_AUTO.as_ptr() as *const i8);
+                }
+                FlowAckMode::Client => {
+                    props.push(ffi::SOLCLIENT_FLOW_PROP_ACKMODE_CLIENT.as_ptr() as *const i8);
+                }
+            }
+        }
+
+        if let Some(topic) = &self.topic {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_TOPIC.as_ptr() as *const i8);
+            props.push(topic.as_ptr());
+        }
+
+        if let Some(max_bind_tries) = &self.max_bind_tries {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_MAX_BIND_TRIES.as_ptr() as *const i8);
+            props.push(max_bind_tries.as_ptr());
+        }
+
+        if let Some(ack_timer_ms) = &self.ack_timer_ms {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_ACK_TIMER_MS.as_ptr() as *const i8);
+            props.push(ack_timer_ms.as_ptr());
+        }
+
+        if let Some(ack_threshold) = &self.ack_threshold {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_ACK_THRESHOLD.as_ptr() as *const i8);
+            props.push(ack_threshold.as_ptr());
+        }
+
+        if let Some(start_state) = &self.start_state {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_START_STATE.as_ptr() as *const i8);
+            props.push(bool_to_ptr(*start_state));
+        }
+
+        if let Some(selector) = &self.selector {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_SELECTOR.as_ptr() as *const i8);
+            props.push(selector.as_ptr());
+        }
+
+        if let Some(no_local) = &self.no_local {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_NO_LOCAL.as_ptr() as *const i8);
+            props.push(bool_to_ptr(*no_local));
+        }
+
+        if let Some(max_unacked_messages) = &self.max_unacked_messages {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_MAX_UNACKED_MESSAGES.as_ptr() as *const i8);
+            props.push(max_unacked_messages.as_ptr());
+        }
+
+        if let Some(browser) = &self.browser {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_BROWSER.as_ptr() as *const i8);
+            props.push(bool_to_ptr(*browser));
+        }
+
+        if let Some(active_flow_ind) = &self.active_flow_ind {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_ACTIVE_FLOW_IND.as_ptr() as *const i8);
+            props.push(bool_to_ptr(*active_flow_ind));
+        }
+
+        if let Some(replay_start_location) = &self.replay_start_location {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION.as_ptr() as *const i8);
+            props.push(replay_start_location.as_ptr());
+        }
+
+        if let Some(max_reconnect_tries) = &self.max_reconnect_tries {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_MAX_RECONNECT_TRIES.as_ptr() as *const i8);
+            props.push(max_reconnect_tries.as_ptr());
+        }
+
+        if let Some(reconnect_retry_interval_ms) = &self.reconnect_retry_interval_ms {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_RECONNECT_RETRY_INTERVAL_MS.as_ptr() as *const i8);
+            props.push(reconnect_retry_interval_ms.as_ptr());
+        }
+
+        if let Some(required_outcome_failed) = &self.required_outcome_failed {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_REQUIRED_OUTCOME_FAILED.as_ptr() as *const i8);
+            props.push(bool_to_ptr(*required_outcome_failed));
+        }
+
+        if let Some(required_outcome_rejected) = &self.required_outcome_rejected {
+            props.push(ffi::SOLCLIENT_FLOW_PROP_REQUIRED_OUTCOME_REJECTED.as_ptr() as *const i8);
+            props.push(bool_to_ptr(*required_outcome_rejected));
+        }
+
+        props.push(std::ptr::null());
+
+        props
+    }
+}
+
+impl TryFrom<UncheckedFlowProps> for CheckedFlowProps {
+    type Error = FlowBuilderError;
+
+    fn try_from(props: UncheckedFlowProps) -> Result<Self> {
+        let bind_timeout_ms = match props.bind_timeout_ms {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let bind_entity_id = match props.bind_entity_id {
+            Some(x) => Some(x.try_into()?),
+            None => None,
+        };
+
+        let bind_entity_durable = props.bind_entity_durable;
+
+        let window_size = match props.window_size {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let ack_mode = props.ack_mode;
+
+        let topic = match props.topic {
+            Some(x) => Some(CString::new(x)?),
+            None => None,
+        };
+
+        let max_bind_tries = match props.max_bind_tries {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let ack_timer_ms = match props.ack_timer_ms {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let ack_threshold = match props.ack_threshold {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let start_state = props.start_state;
+
+        let selector = match props.selector {
+            Some(x) => Some(CString::new(x)?),
+            None => None,
+        };
+
+        let no_local = props.no_local;
+
+        let max_unacked_messages = match props.max_unacked_messages {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let browser = props.browser;
+
+        let active_flow_ind = props.active_flow_ind;
+
+        let replay_start_location = match props.replay_start_location {
+            Some(x) => Some(CString::new(x)?),
+            None => None,
+        };
+
+        let max_reconnect_tries = match props.max_reconnect_tries {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let reconnect_retry_interval_ms = match props.reconnect_retry_interval_ms {
+            Some(x) => Some(CString::new(x.to_string())?),
+            None => None,
+        };
+
+        let required_outcome_failed = props.required_outcome_failed;
+
+        let required_outcome_rejected = props.required_outcome_rejected;
+
+        Ok(Self {
+            bind_timeout_ms,
+            bind_entity_id,
+            bind_entity_durable,
+            window_size,
+            ack_mode,
+            topic,
+            max_bind_tries,
+            ack_timer_ms,
+            ack_threshold,
+            start_state,
+            selector,
+            no_local,
+            max_unacked_messages,
+            browser,
+            active_flow_ind,
+            replay_start_location,
+            max_reconnect_tries,
+            reconnect_retry_interval_ms,
+            required_outcome_failed,
+            required_outcome_rejected,
+        })
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FlowBindEntityId<T> {
+    Sub,
+    Queue { queue_name: T },
+    Te { topic_endpoint_name: T },
+}
+impl TryFrom<FlowBindEntityId<String>> for FlowBindEntityId<CString> {
+    type Error = FlowBuilderError;
+
+    fn try_from(value: FlowBindEntityId<String>) -> Result<Self> {
+        match value {
+            FlowBindEntityId::Sub => Ok(FlowBindEntityId::Sub),
+            FlowBindEntityId::Queue { queue_name } => Ok(FlowBindEntityId::Queue {
+                queue_name: CString::new(queue_name)?,
+            }),
+            FlowBindEntityId::Te {
+                topic_endpoint_name,
+            } => Ok(FlowBindEntityId::Te {
+                topic_endpoint_name: CString::new(topic_endpoint_name)?,
+            }),
+        }
+    }
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FlowAckMode {
+    Auto,
+    Client,
+}
+
+#[derive(Debug, PartialEq, Eq, Clone)]
+pub enum FlowBindEntityDurable {
+    Durable,
+    NonDurable { endpoint_props: EndpointProps },
+}

--- a/src/flow/builder.rs
+++ b/src/flow/builder.rs
@@ -31,6 +31,8 @@ pub enum FlowBuilderError {
 
 type Result<T> = std::result::Result<T, FlowBuilderError>;
 
+/// Flow Configuration Properties
+/// https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/group__flow_props.html
 #[derive(Debug, PartialEq, Eq, Clone, Default)]
 struct UncheckedFlowProps {
     bind_timeout_ms: Option<u32>,
@@ -166,111 +168,180 @@ where
         }
     }
 
+    /// Sets the timeout (in milliseconds) used when creating a Flow in blocking mode.
+    ///
+    /// The valid range is > 0. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_BIND_TIMEOUT_MS]
     pub fn bind_timeout_ms(mut self, timeout: u32) -> Self {
         self.props.bind_timeout_ms = Some(timeout);
         self
     }
 
+    /// Sets the type of object to which this Flow is bound.
+    ///
+    /// The valid values are SOLCLIENT_FLOW_PROP_BIND_ENTITY_SUB, SOLCLIENT_FLOW_PROP_BIND_ENTITY_QUEUE, and SOLCLIENT_FLOW_PROP_BIND_ENTITY_TE.
+    /// Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_BIND_ENTITY_ID]
     pub fn bind_entity_id(mut self, entity_id: FlowBindEntityId<String>) -> Self {
         self.props.bind_entity_id = Some(entity_id);
         self
     }
 
+    /// Sets the durability of the object to which this Flow is bound.
+    ///
+    /// Default: [ffi::SOLCLIENT_PROP_ENABLE_VAL], which means the endpoint is durable. When set to [ffi::SOLCLIENT_PROP_DISABLE_VAL], a temporary endpoint is created.
     pub fn bind_entity_durable(mut self, durable: FlowBindEntityDurable) -> Self {
         self.props.bind_entity_durable = Some(durable);
         self
     }
 
+    /// Sets the Guaranteed message window size for the Flow.
+    ///
+    /// This sets the maximum number of messages that can be in transit (that is, the messages are sent from the broker but are not yet delivered to the application).
+    /// The valid range is 1..255. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_WINDOWSIZE]
     pub fn window_size(mut self, size: u32) -> Self {
         self.props.window_size = Some(size);
         self
     }
 
+    /// Sets the acknowledgment mode for the Flow.
+    ///
+    /// Possible values are SOLCLIENT_FLOW_PROP_ACKMODE_AUTO and SOLCLIENT_FLOW_PROP_ACKMODE_CLIENT. Default: SOLCLIENT_FLOW_PROP_ACKMODE_AUTO
     pub fn ack_mode(mut self, mode: FlowAckMode) -> Self {
         self.props.ack_mode = Some(mode);
         self
     }
 
+    /// Sets the topic to which the Flow is bound.
+    ///
+    /// When binding to a Topic endpoint, the Topic may be set in the bind. This parameter is ignored for Queue or subscriber binding.
+    /// The maximum length (not including NULL terminator) is SOLCLIENT_BUFINFO_MAX_TOPIC_SIZE. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_TOPIC]
     pub fn topic(mut self, topic: String) -> Self {
         self.props.topic = Some(topic);
         self
     }
 
+    /// Sets the maximum number of attempts to bind the Flow.
+    ///
+    /// The valid range is >= 1. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_MAX_BIND_TRIES]
     pub fn max_bind_tries(mut self, tries: u32) -> Self {
         self.props.max_bind_tries = Some(tries);
         self
     }
 
+    /// Sets the timer (in milliseconds) for sending acknowledgments.
+    ///
+    /// The valid range is 20..1500. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_ACK_TIMER_MS]
     pub fn ack_timer_ms(mut self, timer: u32) -> Self {
         self.props.ack_timer_ms = Some(timer);
         self
     }
 
+    /// Sets the threshold for sending an acknowledgment, configured as a percentage.
+    ///
+    /// The valid range is 1..75. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_ACK_THRESHOLD]
     pub fn ack_threshold(mut self, threshold: u8) -> Self {
         self.props.ack_threshold = Some(threshold);
         self
     }
 
+    /// Controls whether the Flow should be created in a start or stop state with respect to receiving messages.
+    ///
+    /// Flow start/stop state can be changed later through solClient_flow_start() or solClient_flow_stop(). Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_START_STATE]
     pub fn start_state(mut self, state: bool) -> Self {
         self.props.start_state = Some(state);
         self
     }
 
+    /// Sets the selector for filtering messages on the Flow.
+    ///
+    /// A Java Message System (JMS) defined selector.
     pub fn selector(mut self, selector: String) -> Self {
         self.props.selector = Some(selector);
         self
     }
 
+    /// Controls whether the Flow should exclude messages published by the same client.
+    ///
+    /// When a Flow has the No Local property enabled, messages published on the Session cannot appear in a Flow created in the same Session, even if the endpoint contains a subscription that matches the published message.
     pub fn no_local(mut self, no_local: bool) -> Self {
         self.props.no_local = Some(no_local);
         self
     }
 
+    /// Sets the maximum number of unacknowledged messages allowed on the Flow.
+    ///
+    /// This property may only be set when the Flow property SOLCLIENT_FLOW_PROP_ACKMODE is set to SOLCLIENT_FLOW_PROP_ACKMODE_CLIENT.
+    /// Valid values are -1 and >0. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_MAX_UNACKED_MESSAGES]
     pub fn max_unacked_messages(mut self, max: u32) -> Self {
         self.props.max_unacked_messages = Some(max);
         self
     }
 
+    /// Indicates whether the Flow operates in browser mode.
+    ///
+    /// A browser flow allows client applications to look at messages spooled on Endpoints without removing them. Messages are browsed from oldest to newest.
+    /// Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_BROWSER]
     pub fn browser(mut self, browser: bool) -> Self {
         self.props.browser = Some(browser);
         self
     }
 
+    /// Enables Active Flow Indication, which sends events when the Flow becomes active or inactive.
+    ///
+    /// If the underlying session capabilities indicate that the broker does not support active flow indications, then solClient_session_createFlow() will fail immediately.
+    /// Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_ACTIVE_FLOW_IND]
     pub fn active_flow_ind(mut self, active: bool) -> Self {
         self.props.active_flow_ind = Some(active);
         self
     }
 
+    /// Sets the starting location for replaying messages on the Flow.
+    ///
+    /// The replay start location may be SOLCLIENT_FLOW_PROP_REPLAY_START_LOCATION_BEGINNING to indicate that all messages available should be replayed.
+    /// Examples: ex/messageReplay.c, and ex/simpleFlowToQueue.c.
     pub fn replay_start_location(mut self, location: String) -> Self {
         self.props.replay_start_location = Some(location);
         self
     }
 
+    /// Sets the maximum number of attempts to reconnect the Flow.
+    ///
+    /// If this property is -1, it will retry forever. Otherwise it tries the configured maximum number of times. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_MAX_RECONNECT_TRIES]
     pub fn max_reconnect_tries(mut self, tries: u32) -> Self {
         self.props.max_reconnect_tries = Some(tries);
         self
     }
 
+    /// Sets the interval (in milliseconds) between reconnect attempts for the Flow.
+    ///
+    /// Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_RECONNECT_RETRY_INTERVAL_MS]
     pub fn reconnect_retry_interval_ms(mut self, interval: u32) -> Self {
         self.props.reconnect_retry_interval_ms = Some(interval);
         self
     }
 
+    /// Indicates whether the Flow requires an outcome of "failed" for messages.
+    ///
+    /// Ignored on transacted sessions. Requires [ffi::SOLCLIENT_SESSION_CAPABILITY_AD_APP_ACK_FAILED]. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_REQUIRED_OUTCOME_FAILED]
     pub fn required_outcome_failed(mut self, failed: bool) -> Self {
         self.props.required_outcome_failed = Some(failed);
         self
     }
 
+    /// Indicates whether the Flow requires an outcome of "rejected" for messages.
+    ///
+    /// Ignored on transacted sessions. Requires [ffi::SOLCLIENT_SESSION_CAPABILITY_AD_APP_ACK_FAILED]. Default: [ffi::SOLCLIENT_FLOW_PROP_DEFAULT_REQUIRED_OUTCOME_REJECTED]
     pub fn required_outcome_rejected(mut self, rejected: bool) -> Self {
         self.props.required_outcome_rejected = Some(rejected);
         self
     }
 
+    /// Sets the callback for handling inbound messages on the Flow.
     pub fn on_message(mut self, on_message: FM) -> Self {
         self.on_message = Some(on_message);
         self
     }
 
+    /// Sets the callback for handling events on the Flow.
     pub fn on_event(mut self, on_event: FE) -> Self {
         self.on_event = Some(on_event);
         self

--- a/src/flow/builder.rs
+++ b/src/flow/builder.rs
@@ -161,7 +161,7 @@ where
             Ok(Flow {
                 lifetime: PhantomData,
                 _flow_ptr: flow_ptr,
-                session: &self.session,
+                session: self.session,
                 _msg_fn_ptr: msg_func_ptr,
                 _event_fn_ptr: event_func_ptr,
             })
@@ -534,7 +534,7 @@ impl TryFrom<UncheckedFlowProps> for CheckedFlowProps {
     fn try_from(props: UncheckedFlowProps) -> Result<Self> {
         let bind_timeout_ms = match props.bind_timeout_ms {
             Some(x) => {
-                if x <= 0 {
+                if x == 0 {
                     return Err(FlowBuilderError::OutOfRangedArgs(
                         "bind_time_out".to_string(),
                         "> 0".to_string(),
@@ -616,7 +616,7 @@ impl TryFrom<UncheckedFlowProps> for CheckedFlowProps {
 
         let ack_timer_ms = match props.ack_timer_ms {
             Some(x) => {
-                if x < 20 || x > 1500 {
+                if !(20..=1500).contains(&x) {
                     return Err(FlowBuilderError::OutOfRangedArgs(
                         "ack_timer_ms".to_string(),
                         "20 <= x <= 1500".to_string(),
@@ -630,7 +630,7 @@ impl TryFrom<UncheckedFlowProps> for CheckedFlowProps {
 
         let ack_threshold = match props.ack_threshold {
             Some(x) => {
-                if x < 1 || x > 75 {
+                if !(1..=75).contains(&x) {
                     return Err(FlowBuilderError::OutOfRangedArgs(
                         "ack_threshold".to_string(),
                         "1 <= x <= 75".to_string(),

--- a/src/flow/callback.rs
+++ b/src/flow/callback.rs
@@ -1,0 +1,92 @@
+use num_traits::FromPrimitive;
+use solace_rs_sys as ffi;
+use std::mem;
+
+use crate::message::InboundMessage;
+
+use super::event::FlowEvent;
+
+pub(crate) fn on_message_trampoline<'s, F>(
+    _closure: &'s F,
+) -> ffi::solClient_flow_rxMsgCallbackFunc_t
+where
+    F: FnMut(InboundMessage) + Send + 's,
+{
+    Some(static_on_message::<F>)
+}
+
+pub(crate) fn on_event_trampoline<'s, F>(_closure: &'s F) -> ffi::solClient_flow_eventCallbackFunc_t
+where
+    F: FnMut(FlowEvent) + Send + 's,
+{
+    Some(static_on_event::<F>)
+}
+
+pub(crate) extern "C" fn static_no_op_on_message(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt,
+    _msg_p: ffi::solClient_opaqueMsg_pt,
+    _raw_user_closure: *mut ::std::os::raw::c_void,
+) -> ffi::solClient_rxMsgCallback_returnCode_t {
+    ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_OK
+}
+
+extern "C" fn static_on_message<'s, F>(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt, // non-null
+    msg_p: ffi::solClient_opaqueMsg_pt,           // non-null
+    raw_user_closure: *mut ::std::os::raw::c_void, // can be null
+) -> ffi::solClient_rxMsgCallback_returnCode_t
+where
+    // not completely sure if this is supposed to be FnMut or FnOnce
+    // threading takes in FnOnce - that is why I suspect it might be FnOnce.
+    // But not enough knowledge to make sure it is FnOnce.
+    F: FnMut(InboundMessage) + Send + 's,
+{
+    // this function is glue code to allow users to pass in closures
+    // we duplicate the message pointer (which does not copy over the binary data)
+    // also this function will only be called from the context thread, so it should be thread safe
+    // as well
+
+    let non_null_raw_user_closure = std::ptr::NonNull::new(raw_user_closure);
+
+    let Some(raw_user_closure) = non_null_raw_user_closure else {
+        return ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_OK;
+    };
+
+    let message = InboundMessage::from(msg_p);
+    let user_closure: &mut Box<F> = unsafe { mem::transmute(raw_user_closure) };
+    user_closure(message);
+
+    ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_TAKE_MSG
+}
+
+pub(crate) extern "C" fn static_no_op_on_event(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt, // non-null
+    _event_info_p: ffi::solClient_flow_eventCallbackInfo_pt, //non-null
+    _raw_user_closure: *mut ::std::os::raw::c_void, // can be null
+) {
+}
+
+extern "C" fn static_on_event<'s, F>(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt, // non-null
+    event_info_p: ffi::solClient_flow_eventCallbackInfo_pt, //non-null
+    raw_user_closure: *mut ::std::os::raw::c_void, // can be null
+) where
+    F: FnMut(FlowEvent) + Send + 's,
+{
+    let non_null_raw_user_closure = std::ptr::NonNull::new(raw_user_closure);
+
+    let Some(raw_user_closure) = non_null_raw_user_closure else {
+        return;
+    };
+    let raw_event = unsafe { (*event_info_p).flowEvent };
+
+    let Some(event) = FlowEvent::from_u32(raw_event) else {
+        // TODO
+        // log a warning
+        return;
+    };
+
+    let user_closure: &mut Box<F> = unsafe { mem::transmute(raw_user_closure) };
+
+    user_closure(event);
+}

--- a/src/flow/event.rs
+++ b/src/flow/event.rs
@@ -1,0 +1,18 @@
+use enum_primitive::*;
+use solace_rs_sys as ffi;
+
+enum_from_primitive! {
+    #[derive(Debug, PartialEq, Eq, Copy, Clone)]
+    #[repr(u32)]
+    pub enum FlowEvent {
+        UpNotice = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_UP_NOTICE,
+        DownError = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_DOWN_ERROR,
+        BindFailedError = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_BIND_FAILED_ERROR,
+        RejectedMsgError = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_REJECTED_MSG_ERROR,
+        SessionDown = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_SESSION_DOWN,
+        Active = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_ACTIVE,
+        Inactive = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_INACTIVE,
+        Reconnecting = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_RECONNECTING,
+        Reconnected = ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_RECONNECTED,
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -137,5 +137,5 @@ pub enum SessionError {
     #[error("could not provision endpoint. SolClient return code: {0} subcode: {1}")]
     EndpointProvisionError(SolClientReturnCode, SolClientSubCode),
     #[error("could not deprovision endpoint. SolClient return code: {0} subcode: {1}")]
-    EndPointDeprovisionError(SolClientReturnCode, SolClientSubCode),
+    EndpointDeprovisionError(SolClientReturnCode, SolClientSubCode),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 pub mod cache_session;
 pub mod context;
+pub mod endpoint_props;
 pub mod message;
 pub mod session;
 pub(crate) mod util;
@@ -132,4 +133,8 @@ pub enum SessionError {
     PublishError(SolClientReturnCode, SolClientSubCode),
     #[error("could not send request. SolClient return code: {0}")]
     RequestError(SolClientReturnCode, SolClientSubCode),
+    #[error("could not provision endpoint. SolClient return code: {0} subcode: {1}")]
+    EndpointProvisionError(SolClientReturnCode, SolClientSubCode),
+    #[error("could not deprovision endpoint. SolClient return code: {0} subcode: {1}")]
+    EndPointDeprovisionError(SolClientReturnCode, SolClientSubCode),
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod cache_session;
 pub mod context;
 pub mod endpoint_props;
+pub mod flow;
 pub mod message;
 pub mod session;
 pub(crate) mod util;

--- a/src/message/inbound.rs
+++ b/src/message/inbound.rs
@@ -1,7 +1,8 @@
 use super::{CacheStatus, Message, MessageError, Result};
-use crate::SolClientReturnCode;
+use crate::util::get_last_error_info;
+use crate::{SolClientReturnCode, SolClientSubCode};
 use enum_primitive::*;
-use solace_rs_sys as ffi;
+use solace_rs_sys::{self as ffi, solClient_msgId_t};
 use std::convert::From;
 use std::ffi::CStr;
 use std::time::{Duration, SystemTime};
@@ -12,86 +13,12 @@ pub struct InboundMessage {
     _msg_ptr: ffi::solClient_opaqueMsg_pt,
 }
 
+impl InboundMessageTrait<'_> for InboundMessage {}
+
 impl fmt::Debug for InboundMessage {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         let mut f = f.debug_struct("InboundMessage");
-        if self.get_receive_timestamp().is_ok_and(|v| v.is_some()) {
-            f.field(
-                "receive_timestamp",
-                &format_args!("{:?}", self.get_receive_timestamp().unwrap().unwrap()),
-            );
-        }
-        if self.get_sender_id().is_ok_and(|v| v.is_some()) {
-            f.field(
-                "sender_id",
-                &format_args!("{}", self.get_sender_id().unwrap().unwrap()),
-            );
-        }
-        if self.get_sender_timestamp().is_ok_and(|v| v.is_some()) {
-            f.field(
-                "sender_timestamp",
-                &format_args!("{:?}", self.get_sender_timestamp().unwrap().unwrap()),
-            );
-        }
-        if self.get_sequence_number().is_ok_and(|v| v.is_some()) {
-            f.field(
-                "sequence_number",
-                &format_args!("{}", self.get_sequence_number().unwrap().unwrap()),
-            );
-        }
-        if self.get_correlation_id().is_ok_and(|v| v.is_some()) {
-            f.field(
-                "correlation_id",
-                &format_args!("{}", self.get_correlation_id().unwrap().unwrap()),
-            );
-        }
-        if self.get_priority().is_ok_and(|v| v.is_some()) {
-            f.field(
-                "priority",
-                &format_args!("{}", self.get_priority().unwrap().unwrap()),
-            );
-        }
-        if self.is_discard_indication() {
-            f.field(
-                "is_discard_indication",
-                &format_args!("{}", self.is_discard_indication()),
-            );
-        }
-        if self.get_application_message_id().is_some() {
-            f.field(
-                "application_message_id",
-                &format_args!("{}", &self.get_application_message_id().unwrap()),
-            );
-        }
-        if self.get_user_data().is_ok_and(|v| v.is_some()) {
-            if let Ok(v) = std::str::from_utf8(self.get_user_data().unwrap().unwrap()) {
-                f.field("user_data", &v);
-            }
-        }
-        if self.get_destination().is_ok_and(|v| v.is_some()) {
-            f.field("destination", &self.get_destination().unwrap().unwrap());
-        }
-
-        f.field("is_reply", &self.is_reply());
-
-        if self.get_reply_to().is_ok_and(|v| v.is_some()) {
-            f.field("reply_to", &self.get_reply_to().unwrap().unwrap());
-        }
-
-        f.field("is_cache_msg", &self.is_cache_msg());
-
-        if self.get_cache_request_id().is_ok_and(|v| v.is_some()) {
-            f.field(
-                "cache_request_id",
-                &self.get_cache_request_id().unwrap().unwrap(),
-            );
-        }
-
-        if self.get_payload().is_ok_and(|v| v.is_some()) {
-            if let Ok(v) = std::str::from_utf8(self.get_payload().unwrap().unwrap()) {
-                f.field("payload", &v);
-            }
-        }
+        debug_inbound_message_fields(self, &mut f);
         f.finish()
     }
 }
@@ -130,8 +57,101 @@ impl<'a> Message<'a> for InboundMessage {
     }
 }
 
-impl InboundMessage {
-    pub fn get_receive_timestamp(&self) -> Result<Option<SystemTime>> {
+pub struct FlowInboundMessage {
+    _msg_ptr: ffi::solClient_opaqueMsg_pt,
+    _flow_ptr: ffi::solClient_opaqueFlow_pt,
+}
+
+impl InboundMessageTrait<'_> for FlowInboundMessage {}
+
+impl fmt::Debug for FlowInboundMessage {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let mut f = f.debug_struct("FlowInboundMessage");
+        debug_inbound_message_fields(self, &mut f);
+        f.finish()
+    }
+}
+
+unsafe impl Send for FlowInboundMessage {}
+
+impl Drop for FlowInboundMessage {
+    fn drop(&mut self) {
+        let rc = unsafe { ffi::solClient_msg_free(&mut self._msg_ptr) };
+
+        let rc = SolClientReturnCode::from_raw(rc);
+        if !rc.is_ok() {
+            warn!("warning: message was not dropped properly");
+        }
+    }
+}
+
+impl From<(ffi::solClient_opaqueMsg_pt, ffi::solClient_opaqueFlow_pt)> for FlowInboundMessage {
+    /// .
+    ///
+    /// # Safety
+    ///
+    /// From a valid owned pointer.
+    /// No other alias should exist for this pointer
+    /// FlowInboundMessage will try to free the ptr when it is destroyed
+    ///
+    /// .
+    fn from(
+        (_msg_ptr, _flow_ptr): (ffi::solClient_opaqueMsg_pt, ffi::solClient_opaqueFlow_pt),
+    ) -> Self {
+        Self {
+            _msg_ptr,
+            _flow_ptr,
+        }
+    }
+}
+
+impl<'a> Message<'a> for FlowInboundMessage {
+    unsafe fn get_raw_message_ptr(&self) -> ffi::solClient_opaqueMsg_pt {
+        self._msg_ptr
+    }
+}
+
+#[derive(thiserror::Error, Debug)]
+pub enum FlowInboundMessageAckError {
+    #[error("Invalid message: subcode {0}")]
+    InvalidMessage(SolClientSubCode),
+    #[error("Message not found")]
+    MessageNotFound,
+    #[error("Ack failed: subcode {0}")]
+    AckFailed(SolClientSubCode),
+}
+
+impl FlowInboundMessage {
+    pub fn try_ack(&self) -> std::result::Result<(), FlowInboundMessageAckError> {
+        let mut message_id: solClient_msgId_t = 0;
+        let get_message_id_return_code = unsafe {
+            let get_message_id_return_code_raw =
+                ffi::solClient_msg_getMsgId(self._msg_ptr, &mut message_id);
+            SolClientReturnCode::from_raw(get_message_id_return_code_raw)
+        };
+        if let SolClientReturnCode::NotFound = get_message_id_return_code {
+            return Err(FlowInboundMessageAckError::MessageNotFound);
+        }
+        if !get_message_id_return_code.is_ok() {
+            return Err(FlowInboundMessageAckError::InvalidMessage(
+                get_last_error_info(),
+            ));
+        }
+
+        let send_ack_return_code = unsafe {
+            let send_ack_return_code_raw = ffi::solClient_flow_sendAck(self._flow_ptr, message_id);
+            SolClientReturnCode::from_raw(send_ack_return_code_raw)
+        };
+        if !send_ack_return_code.is_ok() {
+            return Err(FlowInboundMessageAckError::AckFailed(get_last_error_info()));
+        }
+
+        Ok(())
+    }
+}
+
+pub trait InboundMessageTrait<'a>: Message<'a> {
+    fn get_receive_timestamp(&'a self) -> Result<Option<SystemTime>> {
         let mut ts: i64 = 0;
         let rc = unsafe { ffi::solClient_msg_getRcvTimestamp(self.get_raw_message_ptr(), &mut ts) };
 
@@ -145,7 +165,7 @@ impl InboundMessage {
         }
     }
 
-    pub fn get_sender_id(&self) -> Result<Option<&str>> {
+    fn get_sender_id(&'a self) -> Result<Option<&'a str>> {
         let mut buffer = ptr::null();
 
         let rc = unsafe { ffi::solClient_msg_getSenderId(self.get_raw_message_ptr(), &mut buffer) };
@@ -166,7 +186,7 @@ impl InboundMessage {
         Ok(Some(str))
     }
 
-    pub fn is_discard_indication(&self) -> bool {
+    fn is_discard_indication(&'a self) -> bool {
         let discard_indication =
             unsafe { ffi::solClient_msg_isDiscardIndication(self.get_raw_message_ptr()) };
 
@@ -177,7 +197,7 @@ impl InboundMessage {
         true
     }
 
-    pub fn get_cache_request_id(&self) -> Result<Option<u64>> {
+    fn get_cache_request_id(&'a self) -> Result<Option<u64>> {
         let mut id: u64 = 0;
 
         let rc =
@@ -191,8 +211,91 @@ impl InboundMessage {
         }
     }
 
-    pub fn is_cache_msg(&self) -> CacheStatus {
+    fn is_cache_msg(&'a self) -> CacheStatus {
         let raw = unsafe { ffi::solClient_msg_isCacheMsg(self.get_raw_message_ptr()) };
         CacheStatus::from_i32(raw).unwrap_or(CacheStatus::InvalidMessage)
+    }
+}
+
+pub fn debug_inbound_message_fields<'a, M: InboundMessageTrait<'a>>(
+    message: &'a M,
+    f: &mut fmt::DebugStruct<'_, '_>,
+) {
+    if message.get_receive_timestamp().is_ok_and(|v| v.is_some()) {
+        f.field(
+            "receive_timestamp",
+            &format_args!("{:?}", message.get_receive_timestamp().unwrap().unwrap()),
+        );
+    }
+    if message.get_sender_id().is_ok_and(|v| v.is_some()) {
+        f.field(
+            "sender_id",
+            &format_args!("{}", message.get_sender_id().unwrap().unwrap()),
+        );
+    }
+    if message.get_sender_timestamp().is_ok_and(|v| v.is_some()) {
+        f.field(
+            "sender_timestamp",
+            &format_args!("{:?}", message.get_sender_timestamp().unwrap().unwrap()),
+        );
+    }
+    if message.get_sequence_number().is_ok_and(|v| v.is_some()) {
+        f.field(
+            "sequence_number",
+            &format_args!("{}", message.get_sequence_number().unwrap().unwrap()),
+        );
+    }
+    if message.get_correlation_id().is_ok_and(|v| v.is_some()) {
+        f.field(
+            "correlation_id",
+            &format_args!("{}", message.get_correlation_id().unwrap().unwrap()),
+        );
+    }
+    if message.get_priority().is_ok_and(|v| v.is_some()) {
+        f.field(
+            "priority",
+            &format_args!("{}", message.get_priority().unwrap().unwrap()),
+        );
+    }
+    if message.is_discard_indication() {
+        f.field(
+            "is_discard_indication",
+            &format_args!("{}", message.is_discard_indication()),
+        );
+    }
+    if message.get_application_message_id().is_some() {
+        f.field(
+            "application_message_id",
+            &format_args!("{}", &message.get_application_message_id().unwrap()),
+        );
+    }
+    if message.get_user_data().is_ok_and(|v| v.is_some()) {
+        if let Ok(v) = std::str::from_utf8(message.get_user_data().unwrap().unwrap()) {
+            f.field("user_data", &v);
+        }
+    }
+    if message.get_destination().is_ok_and(|v| v.is_some()) {
+        f.field("destination", &message.get_destination().unwrap().unwrap());
+    }
+
+    f.field("is_reply", &message.is_reply());
+
+    if message.get_reply_to().is_ok_and(|v| v.is_some()) {
+        f.field("reply_to", &message.get_reply_to().unwrap().unwrap());
+    }
+
+    f.field("is_cache_msg", &message.is_cache_msg());
+
+    if message.get_cache_request_id().is_ok_and(|v| v.is_some()) {
+        f.field(
+            "cache_request_id",
+            &message.get_cache_request_id().unwrap().unwrap(),
+        );
+    }
+
+    if message.get_payload().is_ok_and(|v| v.is_some()) {
+        if let Ok(v) = std::str::from_utf8(message.get_payload().unwrap().unwrap()) {
+            f.field("payload", &v);
+        }
     }
 }

--- a/src/message/inbound.rs
+++ b/src/message/inbound.rs
@@ -51,7 +51,7 @@ impl From<ffi::solClient_opaqueMsg_pt> for InboundMessage {
     }
 }
 
-impl<'a> Message<'a> for InboundMessage {
+impl Message<'_> for InboundMessage {
     unsafe fn get_raw_message_ptr(&self) -> ffi::solClient_opaqueMsg_pt {
         self._msg_ptr
     }
@@ -105,7 +105,7 @@ impl From<(ffi::solClient_opaqueMsg_pt, ffi::solClient_opaqueFlow_pt)> for FlowI
     }
 }
 
-impl<'a> Message<'a> for FlowInboundMessage {
+impl Message<'_> for FlowInboundMessage {
     unsafe fn get_raw_message_ptr(&self) -> ffi::solClient_opaqueMsg_pt {
         self._msg_ptr
     }

--- a/src/message/outbound.rs
+++ b/src/message/outbound.rs
@@ -43,7 +43,7 @@ impl Drop for OutboundMessage {
     }
 }
 
-impl<'a> Message<'a> for OutboundMessage {
+impl Message<'_> for OutboundMessage {
     unsafe fn get_raw_message_ptr(&self) -> ffi::solClient_opaqueMsg_pt {
         self._msg_ptr
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -7,6 +7,7 @@ pub use event::SessionEvent;
 use crate::cache_session::CacheSession;
 use crate::context::Context;
 use crate::endpoint_props::EndpointProps;
+use crate::flow::builder::FlowBuilder;
 use crate::message::{InboundMessage, Message, OutboundMessage};
 use crate::util::get_last_error_info;
 use crate::SessionError;
@@ -221,6 +222,12 @@ impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send>
             return Err(SessionError::EndpointProvisionError(rc, subcode));
         }
         Ok(())
+    }
+
+    pub fn flow_builder<'builder, OnMessage, OnEvent>(
+        &'builder self,
+    ) -> FlowBuilder<'builder, 'session, M, E, OnMessage, OnEvent> {
+        FlowBuilder::new(&self)
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -164,12 +164,21 @@ impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send>
         Ok(())
     }
 
-    pub fn endpoint_provision(&self, endpoint_props: EndpointProps) -> Result<()> {
+    pub fn endpoint_provision(
+        &self,
+        endpoint_props: EndpointProps,
+        ignore_already_exists_error: bool,
+    ) -> Result<()> {
+        let mut flag = ffi::SOLCLIENT_PROVISION_FLAGS_WAITFORCONFIRM;
+        if ignore_already_exists_error {
+            flag |= ffi::SOLCLIENT_PROVISION_FLAGS_IGNORE_EXIST_ERRORS;
+        }
+
         let rc = unsafe {
             ffi::solClient_session_endpointProvision(
                 endpoint_props.to_raw().as_mut_ptr(),
                 self._session_ptr,
-                ffi::SOLCLIENT_PROVISION_FLAGS_WAITFORCONFIRM,
+                flag,
                 std::ptr::null_mut(),
                 // deprecated params
                 std::ptr::null_mut(),
@@ -186,12 +195,21 @@ impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send>
         Ok(())
     }
 
-    pub fn endpoint_deprovision(&self, endpoint_props: EndpointProps) -> Result<()> {
+    pub fn endpoint_deprovision(
+        &self,
+        endpoint_props: EndpointProps,
+        ignore_already_exists_error: bool,
+    ) -> Result<()> {
+        let mut flag = ffi::SOLCLIENT_PROVISION_FLAGS_WAITFORCONFIRM;
+        if ignore_already_exists_error {
+            flag |= ffi::SOLCLIENT_PROVISION_FLAGS_IGNORE_EXIST_ERRORS;
+        }
+
         let rc = unsafe {
             ffi::solClient_session_endpointDeprovision(
                 endpoint_props.to_raw().as_mut_ptr(),
                 self._session_ptr,
-                ffi::SOLCLIENT_PROVISION_FLAGS_WAITFORCONFIRM,
+                flag,
                 std::ptr::null_mut(),
             )
         };

--- a/src/session.rs
+++ b/src/session.rs
@@ -219,7 +219,7 @@ impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send>
 
         if !rc.is_ok() {
             let subcode = get_last_error_info();
-            return Err(SessionError::EndpointProvisionError(rc, subcode));
+            return Err(SessionError::EndpointDeprovisionError(rc, subcode));
         }
         Ok(())
     }

--- a/src/session.rs
+++ b/src/session.rs
@@ -228,7 +228,7 @@ impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send>
     pub fn flow_builder<'builder, OnMessage, OnEvent>(
         &'builder self,
     ) -> FlowBuilder<'builder, 'session, M, E, OnMessage, OnEvent> {
-        FlowBuilder::new(&self)
+        FlowBuilder::new(self)
     }
 }
 

--- a/src/session.rs
+++ b/src/session.rs
@@ -176,8 +176,9 @@ impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send>
         }
 
         let rc = unsafe {
+            let mut props_raw = endpoint_props.to_raw();
             ffi::solClient_session_endpointProvision(
-                endpoint_props.to_raw().as_mut_ptr(),
+                props_raw.as_mut_ptr(),
                 self._session_ptr,
                 flag,
                 std::ptr::null_mut(),

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -9,8 +9,8 @@ use crate::{
     message::InboundMessage,
     session::SessionEvent,
     util::{
-        get_last_error_info, on_event_trampoline, on_message_trampoline, static_no_op_on_event,
-        static_no_op_on_message,
+        bool_to_ptr, get_last_error_info, on_event_trampoline, on_message_trampoline,
+        static_no_op_on_event, static_no_op_on_message,
     },
     Context, Session, SolClientReturnCode, SolClientSubCode,
 };
@@ -30,14 +30,6 @@ pub enum SessionBuilderError {
 }
 
 type Result<T> = std::result::Result<T, SessionBuilderError>;
-
-fn bool_to_ptr(b: bool) -> *const i8 {
-    if b {
-        ffi::SOLCLIENT_PROP_ENABLE_VAL.as_ptr() as *const i8
-    } else {
-        ffi::SOLCLIENT_PROP_DISABLE_VAL.as_ptr() as *const i8
-    }
-}
 
 struct UncheckedSessionProps<Host, Vpn, Username, Password> {
     // Note: required params

--- a/src/util.rs
+++ b/src/util.rs
@@ -107,3 +107,11 @@ pub(crate) fn get_last_error_info() -> SolClientSubCode {
         }
     }
 }
+
+pub(crate) fn bool_to_ptr(b: bool) -> *const i8 {
+    if b {
+        ffi::SOLCLIENT_PROP_ENABLE_VAL.as_ptr() as *const i8
+    } else {
+        ffi::SOLCLIENT_PROP_DISABLE_VAL.as_ptr() as *const i8
+    }
+}

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -8,8 +8,8 @@ use std::{
 
 use solace_rs::{
     message::{
-        DeliveryMode, DestinationType, InboundMessage, Message, MessageDestination,
-        OutboundMessageBuilder,
+        inbound::InboundMessageTrait, DeliveryMode, DestinationType, InboundMessage, Message,
+        MessageDestination, OutboundMessageBuilder,
     },
     session::SessionEvent,
     Context, SolaceLogLevel,

--- a/tests/integration_test.rs
+++ b/tests/integration_test.rs
@@ -7,9 +7,12 @@ use std::{
 };
 
 use solace_rs::{
+    endpoint_props::{EndpointId, EndpointPropsBuilder},
+    flow::builder::{FlowAckMode, FlowBindEntityId},
     message::{
-        inbound::InboundMessageTrait, DeliveryMode, DestinationType, InboundMessage, Message,
-        MessageDestination, OutboundMessageBuilder,
+        inbound::{FlowInboundMessage, InboundMessageTrait},
+        DeliveryMode, DestinationType, InboundMessage, Message, MessageDestination,
+        OutboundMessageBuilder,
     },
     session::SessionEvent,
     Context, SolaceLogLevel,
@@ -556,4 +559,189 @@ fn request_and_reply() {
         assert!(res.join().is_ok());
         assert!(req.join().is_ok());
     });
+}
+
+#[test]
+#[ignore]
+fn subscribe_and_publish_with_queue() {
+    let host = option_env!("SOLACE_HOST").unwrap_or(DEFAULT_HOST);
+    let port = option_env!("SOLACE_PORT").unwrap_or(DEFAULT_PORT);
+
+    let solace_context = Context::new(SolaceLogLevel::Warning).unwrap();
+    let (tx, rx) = mpsc::channel();
+    let tx_msgs = vec!["helo", "hello2", "hello4", "helo5"];
+    let queue_name = "subscribe_and_publish_with_queue";
+
+    let on_message = move |message: FlowInboundMessage| {
+        let Ok(Some(payload)) = message.get_payload() else {
+            return;
+        };
+        let _ = tx.send(payload.to_owned());
+    };
+
+    let session = solace_context
+        .session(
+            format!("tcp://{}:{}", host, port),
+            "default",
+            "default",
+            "",
+            None::<fn(InboundMessage)>,
+            None::<fn(SessionEvent)>,
+        )
+        .expect("creating session");
+
+    // Provision a queue
+    let endpoint_props = EndpointPropsBuilder::new()
+        .id(EndpointId::Queue {
+            name: queue_name.to_string(),
+        })
+        .build()
+        .expect("building endpoint props");
+    session
+        .endpoint_provision(endpoint_props.clone(), true)
+        .expect("provisioning queue");
+
+    sleep(SLEEP_TIME);
+
+    // Subscribe to the queue
+    let flow = session
+        .flow_builder()
+        .bind_entity_id(FlowBindEntityId::Queue {
+            queue_name: queue_name.to_string(),
+        })
+        .ack_mode(FlowAckMode::Auto)
+        .on_message(on_message)
+        .on_event(|_| {})
+        .build()
+        .expect("subscribing to queue");
+
+    // need to wait before publishing so that the client is properly subscribed
+    sleep(SLEEP_TIME);
+
+    for msg in tx_msgs.clone() {
+        let dest = MessageDestination::new(DestinationType::Queue, queue_name).unwrap();
+        let outbound_msg = OutboundMessageBuilder::new()
+            .destination(dest)
+            .delivery_mode(DeliveryMode::Persistent)
+            .payload(msg)
+            .build()
+            .expect("building outbound msg");
+        session.publish(outbound_msg).expect("publishing message");
+    }
+    sleep(SLEEP_TIME);
+
+    let mut rx_msgs = vec![];
+
+    loop {
+        match rx.try_recv() {
+            Ok(msg) => {
+                let str = String::from_utf8_lossy(&msg).to_string();
+                rx_msgs.push(str);
+                if rx_msgs.len() == tx_msgs.len() {
+                    break;
+                }
+            }
+            _ => panic!(),
+        }
+    }
+
+    // Deprovision queue and cleanup
+    drop(flow);
+    session.endpoint_deprovision(endpoint_props, true).unwrap();
+    sleep(SLEEP_TIME);
+
+    assert_eq!(tx_msgs, rx_msgs);
+}
+
+#[test]
+#[ignore]
+fn flow_message_ack() {
+    let host = option_env!("SOLACE_HOST").unwrap_or(DEFAULT_HOST);
+    let port = option_env!("SOLACE_PORT").unwrap_or(DEFAULT_PORT);
+    let queue_name = "flow_message_ack";
+    let solace_context = Context::new(SolaceLogLevel::Warning).unwrap();
+    let (tx, rx) = mpsc::channel();
+    let tx_msgs = vec!["ack1", "ack2", "ack3"];
+
+    // Provision a queue
+    let endpoint_props = EndpointPropsBuilder::new()
+        .id(EndpointId::Queue {
+            name: queue_name.to_string(),
+        })
+        .build()
+        .expect("building endpoint props");
+    let session = solace_context
+        .session(
+            format!("tcp://{}:{}", host, port),
+            "default",
+            "default",
+            "",
+            None::<fn(InboundMessage)>,
+            None::<fn(SessionEvent)>,
+        )
+        .expect("creating session");
+    session
+        .endpoint_provision(endpoint_props.clone(), true)
+        .expect("provisioning queue");
+
+    sleep(SLEEP_TIME);
+
+    // Subscribe to the queue with client ack mode
+    let flow = session
+        .flow_builder()
+        .bind_entity_id(FlowBindEntityId::Queue {
+            queue_name: queue_name.to_string(),
+        })
+        .ack_mode(FlowAckMode::Client)
+        .on_message({
+            let tx = tx.clone();
+            move |message: FlowInboundMessage| {
+                let Ok(Some(payload)) = message.get_payload() else {
+                    return;
+                };
+                // Ack the message
+                message.try_ack().expect("acknowledging message");
+                let _ = tx.send(payload.to_owned());
+            }
+        })
+        .on_event(|_| {})
+        .build()
+        .expect("subscribing to queue");
+
+    sleep(SLEEP_TIME);
+
+    // Publish messages
+    for msg in tx_msgs.clone() {
+        let dest = MessageDestination::new(DestinationType::Queue, queue_name).unwrap();
+        let outbound_msg = OutboundMessageBuilder::new()
+            .destination(dest)
+            .delivery_mode(DeliveryMode::Persistent)
+            .payload(msg)
+            .build()
+            .expect("building outbound msg");
+        session.publish(outbound_msg).expect("publishing message");
+    }
+
+    sleep(SLEEP_TIME);
+
+    let mut rx_msgs = vec![];
+    loop {
+        match rx.try_recv() {
+            Ok(msg) => {
+                let str = String::from_utf8_lossy(&msg).to_string();
+                rx_msgs.push(str);
+                if rx_msgs.len() == tx_msgs.len() {
+                    break;
+                }
+            }
+            _ => panic!(),
+        }
+    }
+
+    // Deprovision queue and cleanup
+    drop(flow);
+    session.endpoint_deprovision(endpoint_props, true).unwrap();
+    sleep(SLEEP_TIME);
+
+    assert_eq!(tx_msgs, rx_msgs);
 }


### PR DESCRIPTION
Hello. I'm new to both Solace and C bindings, so I believe your review is necessary. I would especially appreciate it if you could check whether I made any mistakes in the use of `unsafe` blocks.

Inspired by https://docs.solace.com/API-Developer-Online-Ref-Documentation/c/ex_2queue_provision_8c-example.html

## What I did
- `src/session.rs`
  - Added `endpoint_provision()` and `endpoint_deprovision()` functions to `Session`.
  - Added `flow_builder()` to `Session`.
- `src/flow/builder.rs`
  - Creates flow using a builder-style. I used the `SessionBuilder` as a reference.
- `src/endpoint_props.rs`
  - Creates endpoint properties used for flow and provisioning using builder-style. I also referenced the `SessionBuilder`.
- `src/message/inbound.rs`
  - Added `FlowInboundMessage` that has ack function.
  - I tried to reuse code from `InboundMessage`, but it may have made the code messy. I'm sorry about that. If you could suggest a better approach, I’d be happy to try it.

