### PR TITLE
fix: safety hardening and correctness fixes (non-breaking)

### DIFF
--- a/src/cache_session.rs
+++ b/src/cache_session.rs
@@ -27,10 +27,6 @@ unsafe impl<M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send> Send
     for CacheSession<'_, M, E>
 {
 }
-unsafe impl<M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send> Sync
-    for CacheSession<'_, M, E>
-{
-}
 
 impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send> Deref
     for CacheSession<'session, M, E>
@@ -129,11 +125,13 @@ impl<'session, M: FnMut(InboundMessage) + Send, E: FnMut(SessionEvent) + Send>
     {
         let c_topic = CString::new(topic)?;
 
+        // When subscribe=false, add the NO_SUBSCRIBE flag so the broker does not
+        // automatically create a live-data subscription for the caller.
         let flags = if subscribe {
             ffi::SOLCLIENT_CACHEREQUEST_FLAGS_LIVEDATA_FLOWTHRU
-                & ffi::SOLCLIENT_CACHEREQUEST_FLAGS_NO_SUBSCRIBE
         } else {
             ffi::SOLCLIENT_CACHEREQUEST_FLAGS_LIVEDATA_FLOWTHRU
+                | ffi::SOLCLIENT_CACHEREQUEST_FLAGS_NO_SUBSCRIBE
         };
 
         let rc = unsafe {

--- a/src/message/destination.rs
+++ b/src/message/destination.rs
@@ -21,7 +21,7 @@ impl DestinationType {
     pub fn to_i32(&self) -> i32 {
         match self {
             Self::Null => ffi::solClient_destinationType_SOLCLIENT_NULL_DESTINATION,
-            Self::Topic => ffi::solClient_destinationType_SOLCLIENT_TOPIC_TEMP_DESTINATION,
+            Self::Topic => ffi::solClient_destinationType_SOLCLIENT_TOPIC_DESTINATION,
             Self::Queue => ffi::solClient_destinationType_SOLCLIENT_QUEUE_DESTINATION,
             Self::TopicTemp => ffi::solClient_destinationType_SOLCLIENT_TOPIC_TEMP_DESTINATION,
             Self::QueueTemp => ffi::solClient_destinationType_SOLCLIENT_QUEUE_TEMP_DESTINATION,
@@ -60,5 +60,42 @@ impl From<ffi::solClient_destination> for MessageDestination {
         let dest: CString = dest_cstr.into();
 
         MessageDestination { dest_type, dest }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn destination_type_to_i32_maps_correctly() {
+        assert_eq!(
+            DestinationType::Null.to_i32(),
+            ffi::solClient_destinationType_SOLCLIENT_NULL_DESTINATION,
+        );
+        assert_eq!(
+            DestinationType::Topic.to_i32(),
+            ffi::solClient_destinationType_SOLCLIENT_TOPIC_DESTINATION,
+        );
+        assert_eq!(
+            DestinationType::Queue.to_i32(),
+            ffi::solClient_destinationType_SOLCLIENT_QUEUE_DESTINATION,
+        );
+        assert_eq!(
+            DestinationType::TopicTemp.to_i32(),
+            ffi::solClient_destinationType_SOLCLIENT_TOPIC_TEMP_DESTINATION,
+        );
+        assert_eq!(
+            DestinationType::QueueTemp.to_i32(),
+            ffi::solClient_destinationType_SOLCLIENT_QUEUE_TEMP_DESTINATION,
+        );
+    }
+
+    #[test]
+    fn topic_is_not_topic_temp() {
+        assert_ne!(
+            DestinationType::Topic.to_i32(),
+            DestinationType::TopicTemp.to_i32(),
+        );
     }
 }

--- a/src/session/builder.rs
+++ b/src/session/builder.rs
@@ -25,7 +25,7 @@ pub enum SessionBuilderError {
     InvalidArgs(#[from] NulError),
     #[error("{0} arg need to be set")]
     MissingRequiredArgs(String),
-    #[error("{0} valid range is {1} foound {2}")]
+    #[error("{0} valid range is {1} found {2}")]
     InvalidRange(String, String, String),
 }
 
@@ -776,7 +776,7 @@ where
         let connect_retries = match value.connect_retries {
             Some(x) if x < -1 => {
                 return Err(SessionBuilderError::InvalidRange(
-                    "connect_retries ".to_owned(),
+                    "connect_retries".to_owned(),
                     ">= -1".to_owned(),
                     x.to_string(),
                 ));
@@ -788,7 +788,7 @@ where
         let reconnect_retries = match value.reconnect_retries {
             Some(x) if x < -1 => {
                 return Err(SessionBuilderError::InvalidRange(
-                    "reconnect_retries ".to_owned(),
+                    "reconnect_retries".to_owned(),
                     ">= -1".to_owned(),
                     x.to_string(),
                 ));

--- a/src/util.rs
+++ b/src/util.rs
@@ -1,11 +1,12 @@
 use ffi::solClient_getLastErrorInfo;
 use num_traits::FromPrimitive;
 
+use crate::flow::FlowEvent;
 use crate::message::InboundMessage;
 use crate::session::SessionEvent;
 use crate::SolClientSubCode;
 use solace_rs_sys as ffi;
-use std::mem;
+use std::panic;
 
 pub(crate) fn on_message_trampoline<'s, F>(
     _closure: &'s F,
@@ -39,25 +40,20 @@ extern "C" fn static_on_message<'s, F>(
     raw_user_closure: *mut ::std::os::raw::c_void,      // can be null
 ) -> ffi::solClient_rxMsgCallback_returnCode_t
 where
-    // not completely sure if this is supposed to be FnMut or FnOnce
-    // threading takes in FnOnce - that is why I suspect it might be FnOnce.
-    // But not enough knowledge to make sure it is FnOnce.
     F: FnMut(InboundMessage) + Send + 's,
 {
-    // this function is glue code to allow users to pass in closures
-    // we duplicate the message pointer (which does not copy over the binary data)
-    // also this function will only be called from the context thread, so it should be thread safe
-    // as well
-
     let non_null_raw_user_closure = std::ptr::NonNull::new(raw_user_closure);
 
     let Some(raw_user_closure) = non_null_raw_user_closure else {
         return ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_OK;
     };
 
+    // Transfer ownership of the message to InboundMessage; TAKE_MSG must always
+    // be returned after this point so the C library does not double-free.
     let message = InboundMessage::from(msg_p);
-    let user_closure: &mut Box<F> = unsafe { mem::transmute(raw_user_closure) };
-    user_closure(message);
+    let user_closure: &mut Box<F> =
+        unsafe { &mut *(raw_user_closure.as_ptr() as *mut Box<F>) };
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| user_closure(message)));
 
     ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_TAKE_MSG
 }
@@ -84,23 +80,309 @@ extern "C" fn static_on_event<'s, F>(
     let raw_event = unsafe { (*event_info_p).sessionEvent };
 
     let Some(event) = SessionEvent::from_u32(raw_event) else {
-        // TODO
-        // log a warning
         return;
     };
 
-    let user_closure: &mut Box<F> = unsafe { mem::transmute(raw_user_closure) };
+    let user_closure: &mut Box<F> =
+        unsafe { &mut *(raw_user_closure.as_ptr() as *mut Box<F>) };
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| user_closure(event)));
+}
 
-    user_closure(event);
+// --- Flow callback trampolines ---
+
+pub(crate) fn on_flow_message_trampoline<'s, F>(
+    _closure: &'s F,
+) -> ffi::solClient_flow_rxMsgCallbackFunc_t
+where
+    F: FnMut(InboundMessage) + Send + 's,
+{
+    Some(static_on_flow_message::<F>)
+}
+
+pub(crate) fn on_flow_event_trampoline<'s, F>(
+    _closure: &'s F,
+) -> ffi::solClient_flow_eventCallbackFunc_t
+where
+    F: FnMut(FlowEvent) + Send + 's,
+{
+    Some(static_on_flow_event::<F>)
+}
+
+#[allow(dead_code)]
+pub(crate) extern "C" fn static_no_op_on_flow_message(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt,
+    _msg_p: ffi::solClient_opaqueMsg_pt,
+    _raw_user_closure: *mut ::std::os::raw::c_void,
+) -> ffi::solClient_rxMsgCallback_returnCode_t {
+    ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_OK
+}
+
+extern "C" fn static_on_flow_message<'s, F>(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt,
+    msg_p: ffi::solClient_opaqueMsg_pt,
+    raw_user_closure: *mut ::std::os::raw::c_void,
+) -> ffi::solClient_rxMsgCallback_returnCode_t
+where
+    F: FnMut(InboundMessage) + Send + 's,
+{
+    let non_null_raw_user_closure = std::ptr::NonNull::new(raw_user_closure);
+
+    let Some(raw_user_closure) = non_null_raw_user_closure else {
+        return ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_OK;
+    };
+
+    // Transfer ownership of the message to InboundMessage; TAKE_MSG must always
+    // be returned after this point so the C library does not double-free.
+    let message = InboundMessage::from(msg_p);
+    let user_closure: &mut Box<F> =
+        unsafe { &mut *(raw_user_closure.as_ptr() as *mut Box<F>) };
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| user_closure(message)));
+
+    ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_TAKE_MSG
+}
+
+pub(crate) extern "C" fn static_no_op_on_flow_event(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt,
+    _event_info_p: ffi::solClient_flow_eventCallbackInfo_pt,
+    _raw_user_closure: *mut ::std::os::raw::c_void,
+) {
+}
+
+extern "C" fn static_on_flow_event<'s, F>(
+    _opaque_flow_p: ffi::solClient_opaqueFlow_pt,
+    event_info_p: ffi::solClient_flow_eventCallbackInfo_pt,
+    raw_user_closure: *mut ::std::os::raw::c_void,
+) where
+    F: FnMut(FlowEvent) + Send + 's,
+{
+    let non_null_raw_user_closure = std::ptr::NonNull::new(raw_user_closure);
+
+    let Some(raw_user_closure) = non_null_raw_user_closure else {
+        return;
+    };
+    let raw_event = unsafe { (*event_info_p).flowEvent };
+
+    let Some(event) = FlowEvent::from_u32(raw_event) else {
+        return;
+    };
+
+    let user_closure: &mut Box<F> =
+        unsafe { &mut *(raw_user_closure.as_ptr() as *mut Box<F>) };
+    let _ = panic::catch_unwind(panic::AssertUnwindSafe(|| user_closure(event)));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::SolClientReturnCode;
+    use solace_rs_sys as ffi;
+    use std::ptr;
+
+    // --- Helpers ---
+
+    /// Allocate a real Solace message.  solClient_msg_alloc works without a
+    /// running context and is safe to pair with InboundMessage (which calls
+    /// solClient_msg_free on drop).
+    fn alloc_msg() -> ffi::solClient_opaqueMsg_pt {
+        let mut p: ffi::solClient_opaqueMsg_pt = ptr::null_mut();
+        let rc = unsafe { ffi::solClient_msg_alloc(&mut p) };
+        assert_eq!(
+            SolClientReturnCode::from_raw(rc),
+            SolClientReturnCode::Ok,
+            "solClient_msg_alloc failed"
+        );
+        p
+    }
+
+    /// Wrap a concrete `fn(InboundMessage)` in the same double-box layout that
+    /// the session builder uses.  Returns (raw_cookie, owner_box).
+    /// Caller must keep `owner_box` alive for the duration of the callback.
+    fn wrap_msg_fn(
+        f: fn(InboundMessage),
+    ) -> (*mut ::std::os::raw::c_void, Box<Box<fn(InboundMessage)>>) {
+        let mut outer: Box<Box<fn(InboundMessage)>> = Box::new(Box::new(f));
+        let raw = outer.as_mut() as *mut _ as *mut ::std::os::raw::c_void;
+        (raw, outer)
+    }
+
+    /// Same for `fn(SessionEvent)`.
+    fn wrap_event_fn(
+        f: fn(SessionEvent),
+    ) -> (*mut ::std::os::raw::c_void, Box<Box<fn(SessionEvent)>>) {
+        let mut outer: Box<Box<fn(SessionEvent)>> = Box::new(Box::new(f));
+        let raw = outer.as_mut() as *mut _ as *mut ::std::os::raw::c_void;
+        (raw, outer)
+    }
+
+    /// Same for `fn(FlowEvent)`.
+    fn wrap_flow_event_fn(
+        f: fn(FlowEvent),
+    ) -> (*mut ::std::os::raw::c_void, Box<Box<fn(FlowEvent)>>) {
+        let mut outer: Box<Box<fn(FlowEvent)>> = Box::new(Box::new(f));
+        let raw = outer.as_mut() as *mut _ as *mut ::std::os::raw::c_void;
+        (raw, outer)
+    }
+
+    fn make_session_event_info() -> ffi::solClient_session_eventCallbackInfo {
+        ffi::solClient_session_eventCallbackInfo {
+            sessionEvent: ffi::solClient_session_event_SOLCLIENT_SESSION_EVENT_UP_NOTICE,
+            responseCode: 0,
+            info_p: ptr::null(),
+            correlation_p: ptr::null_mut(),
+        }
+    }
+
+    fn make_flow_event_info() -> ffi::solClient_flow_eventCallbackInfo {
+        ffi::solClient_flow_eventCallbackInfo {
+            flowEvent: ffi::solClient_flow_event_SOLCLIENT_FLOW_EVENT_UP_NOTICE,
+            responseCode: 0,
+            info_p: ptr::null(),
+        }
+    }
+
+    // --- static_on_message ---
+
+    #[test]
+    fn on_message_null_closure_returns_callback_ok() {
+        // When the user cookie is null the callback must return CALLBACK_OK
+        // without touching msg_p.
+        let rc = static_on_message::<fn(InboundMessage)>(
+            ptr::null_mut(),
+            ptr::null_mut(), // msg_p irrelevant – early return before use
+            ptr::null_mut(), // null cookie
+        );
+        assert_eq!(
+            rc,
+            ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_OK
+        );
+    }
+
+    #[test]
+    fn on_message_normal_fn_returns_callback_take_msg() {
+        fn noop(_: InboundMessage) {}
+        let msg_p = alloc_msg();
+        let (raw, _owner) = wrap_msg_fn(noop);
+        let rc = static_on_message::<fn(InboundMessage)>(ptr::null_mut(), msg_p, raw);
+        assert_eq!(
+            rc,
+            ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_TAKE_MSG
+        );
+        // InboundMessage::drop called solClient_msg_free; _owner still valid.
+    }
+
+    #[test]
+    fn on_message_panicking_fn_returns_callback_take_msg() {
+        // The panic must be caught by catch_unwind; TAKE_MSG still returned.
+        fn panicking(_: InboundMessage) {
+            panic!("intentional panic – must be caught");
+        }
+        let msg_p = alloc_msg();
+        let (raw, _owner) = wrap_msg_fn(panicking);
+        let rc = static_on_message::<fn(InboundMessage)>(ptr::null_mut(), msg_p, raw);
+        assert_eq!(
+            rc,
+            ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_TAKE_MSG
+        );
+    }
+
+    // --- static_on_flow_message ---
+
+    #[test]
+    fn on_flow_message_null_closure_returns_callback_ok() {
+        let rc = static_on_flow_message::<fn(InboundMessage)>(
+            ptr::null_mut(),
+            ptr::null_mut(),
+            ptr::null_mut(),
+        );
+        assert_eq!(
+            rc,
+            ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_OK
+        );
+    }
+
+    #[test]
+    fn on_flow_message_normal_fn_returns_callback_take_msg() {
+        fn noop(_: InboundMessage) {}
+        let msg_p = alloc_msg();
+        let (raw, _owner) = wrap_msg_fn(noop);
+        let rc = static_on_flow_message::<fn(InboundMessage)>(ptr::null_mut(), msg_p, raw);
+        assert_eq!(
+            rc,
+            ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_TAKE_MSG
+        );
+    }
+
+    #[test]
+    fn on_flow_message_panicking_fn_returns_callback_take_msg() {
+        fn panicking(_: InboundMessage) {
+            panic!("intentional panic – must be caught");
+        }
+        let msg_p = alloc_msg();
+        let (raw, _owner) = wrap_msg_fn(panicking);
+        let rc = static_on_flow_message::<fn(InboundMessage)>(ptr::null_mut(), msg_p, raw);
+        assert_eq!(
+            rc,
+            ffi::solClient_rxMsgCallback_returnCode_SOLCLIENT_CALLBACK_TAKE_MSG
+        );
+    }
+
+    // --- static_on_event ---
+
+    #[test]
+    fn on_event_null_closure_does_not_crash() {
+        let mut info = make_session_event_info();
+        // null cookie → early return, no closure invoked
+        static_on_event::<fn(SessionEvent)>(
+            ptr::null_mut(),
+            &mut info as *mut _,
+            ptr::null_mut(),
+        );
+    }
+
+    #[test]
+    fn on_event_panicking_fn_does_not_abort() {
+        fn panicking(_: SessionEvent) {
+            panic!("intentional panic – must be caught");
+        }
+        let mut info = make_session_event_info();
+        let (raw, _owner) = wrap_event_fn(panicking);
+        static_on_event::<fn(SessionEvent)>(ptr::null_mut(), &mut info as *mut _, raw);
+        // reaching here means catch_unwind prevented abort
+    }
+
+    // --- static_on_flow_event ---
+
+    #[test]
+    fn on_flow_event_null_closure_does_not_crash() {
+        let mut info = make_flow_event_info();
+        static_on_flow_event::<fn(FlowEvent)>(
+            ptr::null_mut(),
+            &mut info as *mut _,
+            ptr::null_mut(),
+        );
+    }
+
+    #[test]
+    fn on_flow_event_panicking_fn_does_not_abort() {
+        fn panicking(_: FlowEvent) {
+            panic!("intentional panic – must be caught");
+        }
+        let mut info = make_flow_event_info();
+        let (raw, _owner) = wrap_flow_event_fn(panicking);
+        static_on_flow_event::<fn(FlowEvent)>(ptr::null_mut(), &mut info as *mut _, raw);
+    }
 }
 
 pub(crate) fn get_last_error_info() -> SolClientSubCode {
-    // Safety: erno is never null
+    // Safety: erno is never null per the Solace C API contract.
     unsafe {
         let erno = solClient_getLastErrorInfo();
         let subcode = (*erno).subCode;
-        let repr_raw: [u8; 256] = mem::transmute((*erno).errorStr);
-        let repr = std::ffi::CStr::from_bytes_until_nul(&repr_raw).unwrap();
+        let error_str_bytes = std::slice::from_raw_parts(
+            (*erno).errorStr.as_ptr() as *const u8,
+            (*erno).errorStr.len(),
+        );
+        let repr = std::ffi::CStr::from_bytes_until_nul(error_str_bytes).unwrap();
         SolClientSubCode {
             subcode,
             error_string: repr.to_string_lossy().to_string(),


### PR DESCRIPTION
## Summary

Fixes several bugs and undefined-behaviour issues identified in #37. All changes are non-breaking.

- Replace `mem::transmute` pointer casts with safe cast chains in all four FFI callback trampolines
- Wrap user closure invocations in `std::panic::catch_unwind(AssertUnwindSafe(...))` to prevent UB from Rust panics unwinding through `extern "C"` frames
- Remove unsound `unsafe impl Sync for CacheSession` (Solace C session handles are not thread-safe)
- Fix inverted bitwise operator in `CacheSession::blocking_cache_request` (`&` → `|` for `NO_SUBSCRIBE` flag)
- Fix `DestinationType::Topic` mapping to use `SOLCLIENT_TOPIC_DESTINATION` instead of `SOLCLIENT_TOPIC_TEMP_DESTINATION`
- Fix typos in `SessionBuilderError` messages (`"foound"`, trailing spaces on two field names)

## Tests

10 new unit tests in `src/util.rs` covering:
- Null closure → early return with `CALLBACK_OK` (all four trampolines)
- Normal closure → correct return code (`CALLBACK_TAKE_MSG` for message trampolines)
- Panicking closure → `catch_unwind` prevents process abort, correct return code still returned

## Checklist

- [x] Non-breaking (no public API changes)
- [x] `cargo check` clean
- [x] `cargo test --lib` passes (26 tests)
- [x] Related issue: #37

🤖 Generated with [Claude Code](https://claude.com/claude-code)